### PR TITLE
[ET-20] JWT 인증 필터 추가

### DIFF
--- a/gateway/src/main/java/com/earlybird/ticket/gateway/infrastructure/config/SecurityWebConfig.java
+++ b/gateway/src/main/java/com/earlybird/ticket/gateway/infrastructure/config/SecurityWebConfig.java
@@ -23,6 +23,10 @@ public class SecurityWebConfig {
                 NoOpServerSecurityContextRepository.getInstance()
             );
 
+        // TODO: JWT 관련 Maanger, Converter 연결
+
+
+        // TODO: 추후 권한별 분기 추가
         http.authorizeExchange(exchanges -> exchanges
 //                    .pathMatchers("api/v1/auth/**").permitAll()
                 .anyExchange().permitAll()

--- a/gateway/src/main/java/com/earlybird/ticket/gateway/infrastructure/security/JwtAuthenticationManager.java
+++ b/gateway/src/main/java/com/earlybird/ticket/gateway/infrastructure/security/JwtAuthenticationManager.java
@@ -1,0 +1,51 @@
+package com.earlybird.ticket.gateway.infrastructure.security;
+
+import com.earlybird.ticket.common.entity.constant.Role;
+import com.earlybird.ticket.gateway.infrastructure.TokenValidator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.ReactiveAuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.SignalType;
+
+@Slf4j(topic = "토큰 추출")
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationManager implements ReactiveAuthenticationManager {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private final TokenValidator tokenValidator;
+
+    @Override
+    public Mono<Authentication> authenticate(Authentication authentication) {
+        return Mono.just(authentication)
+            .doFirst(() -> log.info("인증 전 Bearer prefix 제거"))
+            .map(auth ->
+                ((String) auth.getPrincipal()).substring(BEARER_PREFIX.length())
+            )
+            // 실제 검증 후 인증 객체 생성
+            .doFirst(() -> log.info("JWT 인증 시작"))
+            .doFinally(signalType -> {
+                if (signalType == SignalType.ON_COMPLETE) {
+                    log.info("JWT 인증 완료");
+                } else {
+                    log.info("JWT 인증 실패");
+                }
+            })
+            .map(jwt -> {
+                Role userRole = tokenValidator.getUserRole(jwt);
+                Long userId = tokenValidator.getUserId(jwt);
+                return new UsernamePasswordAuthenticationToken(
+                    userId,
+                    authentication.getCredentials(),
+                    List.of(new SimpleGrantedAuthority("ROLE_" + userRole.getValue()))
+                );
+            });
+
+    }
+}

--- a/gateway/src/main/java/com/earlybird/ticket/gateway/infrastructure/security/JwtServerAuthenticationConverter.java
+++ b/gateway/src/main/java/com/earlybird/ticket/gateway/infrastructure/security/JwtServerAuthenticationConverter.java
@@ -1,0 +1,29 @@
+package com.earlybird.ticket.gateway.infrastructure.security;
+
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.server.authentication.ServerAuthenticationConverter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Slf4j(topic = "JWT 인증 객체 변환")
+@Component
+public class JwtServerAuthenticationConverter implements ServerAuthenticationConverter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+
+    @Override
+    public Mono<Authentication> convert(ServerWebExchange exchange) {
+        return Mono.justOrEmpty(exchange)
+            .doFirst(() -> log.info("헤더 추출"))
+            .flatMap(ex -> Mono.justOrEmpty(
+                ex.getRequest().getHeaders().getFirst(AUTHORIZATION_HEADER)))
+            .filter(Objects::nonNull)
+            // 헤더에서 토큰 추출 후 임시로 Authenticatin 생성 및 ReactiveAuthenticationManager로 넘김
+            .doFirst(() -> log.info("임시 인증 토큰 생성"))
+            .map(auth -> new UsernamePasswordAuthenticationToken(auth, null));
+    }
+}

--- a/gateway/src/main/java/com/earlybird/ticket/gateway/infrastructure/security/filter/AddPassportHeaderGatewayFilter.java
+++ b/gateway/src/main/java/com/earlybird/ticket/gateway/infrastructure/security/filter/AddPassportHeaderGatewayFilter.java
@@ -1,0 +1,89 @@
+package com.earlybird.ticket.gateway.infrastructure.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Slf4j(topic = "권한별 인가")
+@Component
+public class AddPassportHeaderGatewayFilter implements GlobalFilter, Ordered {
+
+    @Override
+    public int getOrder() {
+        return 0;
+    }
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    // TODO: 정규식 패턴으로 변경
+    private final Set<String> ALLOWED_UNAUTHORIZED_REQUEST = Set.of(
+        "/api/v1/auth/sign-in",
+        "/api/v1/auth/customer/sign-up",
+        "/api/v1/auth/seller/sign-up",
+        "/api/v1/auth/withdraw"
+    );
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+
+        return chain.filter(exchange);
+
+        // TODO: JWT 토큰 발급 이후 검증
+        //String path = exchange.getRequest().getURI().getPath();
+        // 회원가입과 로그인 과정은 인증되지 않은 상태이므로 인가 필터 거치지 X
+//        if (ALLOWED_UNAUTHORIZED_REQUEST.contains(path)) {
+//            return chain.filter(exchange)
+//                .doFirst(() -> log.info("no auth request path = {}", path))
+//                .then(Mono.fromRunnable(() -> {
+//                    ServerHttpResponse response = exchange.getResponse();
+//                    log.info("no auth response status code = {}", response.getStatusCode());
+//                }));
+//        }
+//
+//        return getAuthentication()
+//            .doFirst(() -> log.info("auth request path = {}", path))
+//            .flatMap(auth -> {
+//                Long userId = (Long) auth.getPrincipal();
+//                Role userRole = auth.getAuthorities().stream()
+//                    .map(role -> Role.from(
+//                        role.getAuthority().substring("ROLE_".length())))
+//                    .toList()
+//                    .get(0);
+//
+//                PassportDto PassportDto = com.earlybird.ticket.common.entity.PassportDto.builder()
+//                    .userId(userId)
+//                    .userRole(String.valueOf(userRole))
+//                    .build();
+//
+//                try {
+//                    ServerHttpRequest modifiedRequest = exchange.getRequest().mutate()
+//                        .header("X-User-PassportDto",
+//                            objectMapper.writeValueAsString(PassportDto))
+//                        .build();
+//                    return chain.filter(exchange.mutate().request(modifiedRequest).build());
+//                } catch (JsonProcessingException e) {
+//                    return Mono.error(e);
+//                }
+//
+//            });
+
+    }
+
+    private Mono<UsernamePasswordAuthenticationToken> getAuthentication() {
+        return ReactiveSecurityContextHolder.getContext()
+            .doFirst(() -> log.info("인가 토큰 검증"))
+            .map(SecurityContext::getAuthentication)
+            .filter(auth -> auth instanceof UsernamePasswordAuthenticationToken)
+            .cast(UsernamePasswordAuthenticationToken.class);
+
+    }
+}


### PR DESCRIPTION
## 변경 타입

- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 테스트 항목

- [x] 코드가 의도한 대로 동작하는지 테스트 완료
- [ ] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음

## 변경 내용

- **as-is**
    - (변경 전 설명을 여기에 작성)

- **to-be**
    - 헤더에서 토큰을 꺼내오는ServerAuthenticationConverter 추가
    - 임시 인증 객체를 인증 객체로 만든 뒤 검증하는 JwtAuthenticationManager 추가

## 참조

- [ET-20](https://challduck.atlassian.net/jira/software/projects/ET/boards/36?selectedIssue=ET-20)
- resolve #23 

## 코멘트
- 현재는 회원 가입이 구현되어 있지 않아서 JWT 검증 없이 각 서비스로 이동할 수 있습니다.
  - 내일 안으로 회원쪽 기능까지 빠르게 구현해서 연결해보겠습니다. 