### PR TITLE
[ET-45] feat(user) : 회원 탈퇴 기능 구현

### DIFF
--- a/user/src/main/java/com/earlybird/ticket/user/application/service/UserService.java
+++ b/user/src/main/java/com/earlybird/ticket/user/application/service/UserService.java
@@ -20,4 +20,6 @@ public interface UserService {
     GetUserIdPasswordRoleQuery findUserByEmail(String email);
 
     void updateUserCustomer(UpdateUserCustomerCommand updateUserCustomerCommand);
+
+    void deleteUser(String passport);
 }

--- a/user/src/main/java/com/earlybird/ticket/user/application/service/UserServiceImpl.java
+++ b/user/src/main/java/com/earlybird/ticket/user/application/service/UserServiceImpl.java
@@ -70,4 +70,16 @@ public class UserServiceImpl implements UserService {
 
         user.updateCustomerWithoutPassword(updateUserCustomerCommand.toUser());
     }
+
+    @Override
+    @Transactional
+    public void deleteUser(String passport) {
+        PassportDto passportDto = passportUtil.getPassportDto(passport);
+
+        User user = userRepository.findUserByUserId(passportDto.getUserId())
+            .orElseThrow(UserNotFoundException::new);
+
+        user.delete(passportDto.getUserId());
+    }
+
 }

--- a/user/src/main/java/com/earlybird/ticket/user/domain/repository/UserRepository.java
+++ b/user/src/main/java/com/earlybird/ticket/user/domain/repository/UserRepository.java
@@ -6,6 +6,7 @@ import com.earlybird.ticket.user.domain.entity.User;
 import java.util.Optional;
 
 public interface UserRepository {
+
     Optional<User> findUserByUserEmail(String userEmail);
 
     void save(User user);

--- a/user/src/main/java/com/earlybird/ticket/user/presentation/InternalUserController.java
+++ b/user/src/main/java/com/earlybird/ticket/user/presentation/InternalUserController.java
@@ -9,8 +9,10 @@ import com.earlybird.ticket.user.presentation.dto.response.GetUserEmailPasswordR
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -45,5 +47,13 @@ public class InternalUserController {
             userService.findUserByEmail(findUserEmailRequest.email())
         );
         return ResponseEntity.ok(CommonDto.ok(userInfoResponse, "사용자 정보 조회 성공"));
+    }
+
+    @DeleteMapping
+    public ResponseEntity<CommonDto<Void>> deleteUser(
+        @RequestHeader(name = "X-User-Passport") String passport
+    ) {
+        userService.deleteUser(passport);
+        return ResponseEntity.ok(CommonDto.ok(null, "사용자 삭제 완료"));
     }
 }


### PR DESCRIPTION
## 변경 타입

- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 테스트 항목

- [x] 코드가 의도한 대로 동작하는지 테스트 완료
- [ ] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음

## 변경 내용

- **as-is**
    - (변경 전 설명을 여기에 작성)

- **to-be**
    - Auth -> User로 전달 받는 내부용 회원 탈퇴 API 추가
      - RequestHeader로 passport를 전달받아 탈퇴하도록 구현

## 참조
- resolve #76
- [ET-45](https://challduck.atlassian.net/jira/software/projects/ET/boards/36?selectedIssue=ET-45)

## 코멘트

- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)