### PR TITLE
[ET-28], [ET-54] Gateway 수정

### DIFF
--- a/gateway/src/main/java/com/earlybird/ticket/gateway/infrastructure/config/SecurityWebConfig.java
+++ b/gateway/src/main/java/com/earlybird/ticket/gateway/infrastructure/config/SecurityWebConfig.java
@@ -1,13 +1,19 @@
 package com.earlybird.ticket.gateway.infrastructure.config;
 
+import com.earlybird.ticket.gateway.infrastructure.security.JwtAuthenticationManager;
+import com.earlybird.ticket.gateway.infrastructure.security.JwtServerAuthenticationConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.ReactiveAuthenticationManager;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity.CsrfSpec;
 import org.springframework.security.config.web.server.ServerHttpSecurity.FormLoginSpec;
 import org.springframework.security.config.web.server.ServerHttpSecurity.HttpBasicSpec;
 import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.authentication.AuthenticationWebFilter;
+import org.springframework.security.web.server.authentication.ServerAuthenticationConverter;
 import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository;
 
 @Configuration
@@ -15,7 +21,11 @@ import org.springframework.security.web.server.context.NoOpServerSecurityContext
 public class SecurityWebConfig {
 
     @Bean
-    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+    public SecurityWebFilterChain securityWebFilterChain(
+        ServerHttpSecurity http,
+        ReactiveAuthenticationManager jwtAuthenticationManager,
+        ServerAuthenticationConverter jwtAuthenticationConverter
+    ) {
         http.csrf(CsrfSpec::disable)
             .formLogin(FormLoginSpec::disable)
             .httpBasic(HttpBasicSpec::disable)
@@ -24,12 +34,18 @@ public class SecurityWebConfig {
             );
 
         // TODO: JWT 관련 Maanger, Converter 연결
+        AuthenticationWebFilter authenticationWebFilter =
+            new AuthenticationWebFilter(jwtAuthenticationManager);
 
+        authenticationWebFilter.setServerAuthenticationConverter(jwtAuthenticationConverter);
+
+        // 생성한 필터 등록
+        http.addFilterAt(authenticationWebFilter, SecurityWebFiltersOrder.AUTHENTICATION);
 
         // TODO: 추후 권한별 분기 추가
         http.authorizeExchange(exchanges -> exchanges
-//                    .pathMatchers("api/v1/auth/**").permitAll()
-                .anyExchange().permitAll()
+            .pathMatchers("api/v1/auth/**").permitAll()
+            .anyExchange().authenticated()
         );
 
         return http.build();

--- a/gateway/src/main/java/com/earlybird/ticket/gateway/infrastructure/security/JwtServerAuthenticationConverter.java
+++ b/gateway/src/main/java/com/earlybird/ticket/gateway/infrastructure/security/JwtServerAuthenticationConverter.java
@@ -23,7 +23,7 @@ public class JwtServerAuthenticationConverter implements ServerAuthenticationCon
                 ex.getRequest().getHeaders().getFirst(AUTHORIZATION_HEADER)))
             .filter(Objects::nonNull)
             // 헤더에서 토큰 추출 후 임시로 Authenticatin 생성 및 ReactiveAuthenticationManager로 넘김
-            .doFirst(() -> log.info("임시 인증 토큰 생성"))
+            .doOnSuccess(s -> log.info("임시 인증 토큰 생성 = {}", s))
             .map(auth -> new UsernamePasswordAuthenticationToken(auth, null));
     }
 }

--- a/gateway/src/main/java/com/earlybird/ticket/gateway/infrastructure/security/filter/AddPassportHeaderGatewayFilter.java
+++ b/gateway/src/main/java/com/earlybird/ticket/gateway/infrastructure/security/filter/AddPassportHeaderGatewayFilter.java
@@ -1,11 +1,17 @@
 package com.earlybird.ticket.gateway.infrastructure.security.filter;
 
+import com.earlybird.ticket.common.entity.PassportDto;
+import com.earlybird.ticket.common.entity.constant.Role;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Set;
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.security.core.context.SecurityContext;
@@ -19,62 +25,56 @@ public class AddPassportHeaderGatewayFilter implements GlobalFilter, Ordered {
 
     @Override
     public int getOrder() {
-        return 0;
+        return Ordered.HIGHEST_PRECEDENCE;
     }
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     // TODO: 정규식 패턴으로 변경
-    private final Set<String> ALLOWED_UNAUTHORIZED_REQUEST = Set.of(
-        "/api/v1/auth/sign-in",
-        "/api/v1/auth/customer/sign-up",
-        "/api/v1/auth/seller/sign-up",
-        "/api/v1/auth/withdraw"
-    );
+    private final String ALLOWED_UNAUTHORIZED_REQUEST = "^/api/v1/auth(/.*)?$";
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
 
-        return chain.filter(exchange);
-
         // TODO: JWT 토큰 발급 이후 검증
-        //String path = exchange.getRequest().getURI().getPath();
-        // 회원가입과 로그인 과정은 인증되지 않은 상태이므로 인가 필터 거치지 X
-//        if (ALLOWED_UNAUTHORIZED_REQUEST.contains(path)) {
-//            return chain.filter(exchange)
-//                .doFirst(() -> log.info("no auth request path = {}", path))
-//                .then(Mono.fromRunnable(() -> {
-//                    ServerHttpResponse response = exchange.getResponse();
-//                    log.info("no auth response status code = {}", response.getStatusCode());
-//                }));
-//        }
-//
-//        return getAuthentication()
-//            .doFirst(() -> log.info("auth request path = {}", path))
-//            .flatMap(auth -> {
-//                Long userId = (Long) auth.getPrincipal();
-//                Role userRole = auth.getAuthorities().stream()
-//                    .map(role -> Role.from(
-//                        role.getAuthority().substring("ROLE_".length())))
-//                    .toList()
-//                    .get(0);
-//
-//                PassportDto PassportDto = com.earlybird.ticket.common.entity.PassportDto.builder()
-//                    .userId(userId)
-//                    .userRole(String.valueOf(userRole))
-//                    .build();
-//
-//                try {
-//                    ServerHttpRequest modifiedRequest = exchange.getRequest().mutate()
-//                        .header("X-User-PassportDto",
-//                            objectMapper.writeValueAsString(PassportDto))
-//                        .build();
-//                    return chain.filter(exchange.mutate().request(modifiedRequest).build());
-//                } catch (JsonProcessingException e) {
-//                    return Mono.error(e);
-//                }
-//
-//            });
+        String path = exchange.getRequest().getURI().getPath();
+        log.info("path = {}", path);
+//         회원가입과 로그인 과정은 인증되지 않은 상태이므로 인가 필터 거치지 X
+        if (Pattern.matches(ALLOWED_UNAUTHORIZED_REQUEST, path)) {
+            return chain.filter(exchange)
+                .doFirst(() -> log.info("no auth request path = {}", path))
+                .then(Mono.fromRunnable(() -> {
+                    ServerHttpResponse response = exchange.getResponse();
+                    log.info("no auth response status code = {}", response.getStatusCode());
+                }));
+        }
+
+        return getAuthentication()
+            .doFirst(() -> log.info("auth request path = {}", path))
+            .flatMap(auth -> {
+                Long userId = (Long) auth.getPrincipal();
+                Role userRole = auth.getAuthorities().stream()
+                    .map(role -> Role.from(
+                        role.getAuthority().substring("ROLE_".length())))
+                    .toList()
+                    .get(0);
+
+                PassportDto PassportDto = com.earlybird.ticket.common.entity.PassportDto.builder()
+                    .userId(userId)
+                    .userRole(String.valueOf(userRole))
+                    .build();
+
+                try {
+                    ServerHttpRequest modifiedRequest = exchange.getRequest().mutate()
+                        .header("X-User-Passport",
+                            objectMapper.writeValueAsString(PassportDto))
+                        .build();
+                    return chain.filter(exchange.mutate().request(modifiedRequest).build());
+                } catch (JsonProcessingException e) {
+                    return Mono.error(e);
+                }
+
+            });
 
     }
 

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -24,70 +24,70 @@ spring:
           predicates:
             - Path=/api/v1/auth/**
           filters:
-            - RewritePath=/api/v1/auth/(?<segment>.*), /api/v1/external/auth/$\{segment}
+            - RewritePath=/api/v1/auth(?<segment>/?.*), /api/v1/external/auth$\{segment}
 
         - id: admin-service # ✅
           uri: lb://admin-service
           predicates:
             - Path=/api/v1/admin/**
           filters:
-            - RewritePath=/api/v1/admin/(?<segment>.*), /api/v1/external/admin/$\{segment}
+            - RewritePath=/api/v1/admin(?<segment>/?.*), /api/v1/external/admin$\{segment}
 
         - id: user-service # ✅
           uri: lb://user-service
           predicates:
             - Path=/api/v1/users/**
           filters:
-            - RewritePath=/api/v1/users/(?<segment>.*), /api/v1/external/users/$\{segment}
+            - RewritePath=/api/v1/users(?<segment>/?.*), /api/v1/external/users$\{segment}
 
         - id: reservation-service # ✅
           uri: lb://reservation-service
           predicates:
             - Path=/api/v1/reservations/**
           filters:
-            - RewritePath=/api/v1/reservations/(?<segment>.*), /api/v1/external/reservations/$\{segment}
+            - RewritePath=/api/v1/reservations(?<segment>/?.*), /api/v1/external/reservations$\{segment}
 
         - id: concert-service # ✅
           uri: lb://concert-service
           predicates:
             - Path=/api/v1/concerts/**
           filters:
-            - RewritePath=/api/v1/concerts/(?<segment>.*), /api/v1/external/concerts/$\{segment}
+            - RewritePath=/api/v1/concerts(?<segment>/?.*), /api/v1/external/concerts$\{segment}
 
         - id: concert-sequence-service # ✅
           uri: lb://concert-service
           predicates:
             - Path=/api/v1/concertsequence/**
           filters:
-            - RewritePath=/api/v1/concertsequence/(?<segment>.*), /api/v1/external/concertsequence/$\{segment}
+            - RewritePath=/api/v1/concertsequence(?<segment>/?.*), /api/v1/external/concertsequence$\{segment}
 
         - id: coupon-service # ✅
           uri: lb://coupon-service
           predicates:
             - Path=/api/v1/coupons/**
           filters:
-            - RewritePath=/api/v1/coupons/(?<segment>.*), /api/v1/external/coupons/$\{segment}
+            - RewritePath=/api/v1/coupons(?<segment>/?.*), /api/v1/external/coupons$\{segment}
 
         - id: payment-service # ✅
           uri: lb://payment-service
           predicates:
             - Path=/api/v1/payments/**
           filters:
-            - RewritePath=/api/v1/payments/(?<segment>.*), /api/v1/external/payments/$\{segment}
+            - RewritePath=/api/v1/payments(?<segment>/?.*), /api/v1/external/payments$\{segment}
 
         - id: venue-service # ✅
           uri: lb://venue-service
           predicates:
             - Path=/api/v1/venues/**
           filters:
-            - RewritePath=/api/v1/venues/(?<segment>.*), /api/v1/external/venues/$\{segment}
+            - RewritePath=/api/v1/venues(?<segment>/?.*), /api/v1/external/venues$\{segment}
 
         - id: seat-service # ✅
           uri: lb://venue-service
           predicates:
             - Path=/api/v1/seats/**
           filters:
-            - RewritePath=/api/v1/seats/(?<segment>.*), /api/v1/external/seats/$\{segment}
+            - RewritePath=/api/v1/seats(?<segment>/?.*), /api/v1/external/seats$\{segment}
 
 eureka:
   instance:


### PR DESCRIPTION
## 변경 타입

- [ ] 신규 기능 추가/수정
- [x] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 테스트 항목

- [x] 코드가 의도한 대로 동작하는지 테스트 완료
- [ ] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음

## 변경 내용

- **as-is**
    - (변경 전 설명을 여기에 작성)

- **to-be**
    - `api/v1/[도메인]`의 경로로 요청 보낼 때 Gateway에서 정상적인 경로를 생성하지 못하던 문제 발견
      - 경로 캡처가 잘못되어 있던 문제 정상적으로 캡처하도록 수정
    - `ServerHttpSecurity`에 Jwt인증 매니저와 컨버터 연결
## 참조
- resolve #80 
- resolve #69 
- [ET-28](https://challduck.atlassian.net/jira/software/projects/ET/boards/36?selectedIssue=ET-28)
- [ET-54](https://challduck.atlassian.net/jira/software/projects/ET/boards/36?selectedIssue=ET-54)

## 코멘트

- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)