### PR TITLE
[ET-61] fix(user) : InternalUserController 문법 오류 수정

### DIFF
--- a/user/src/main/java/com/earlybird/ticket/user/presentation/InternalUserController.java
+++ b/user/src/main/java/com/earlybird/ticket/user/presentation/InternalUserController.java
@@ -57,6 +57,7 @@ public class InternalUserController {
     ) {
         userService.deleteUser(passport);
         return ResponseEntity.ok(CommonDto.ok(null, "사용자 삭제 완료"));
+    }
 
     @PatchMapping("/change-password")
     public ResponseEntity<CommonDto<Void>> changeUserCustomerPassword(


### PR DESCRIPTION
## 변경 타입

- [ ] 신규 기능 추가/수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 테스트 항목

- [ ] 코드가 의도한 대로 동작하는지 테스트 완료
- [x] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음

## 변경 내용

- **as-is**
    - (변경 전 설명을 여기에 작성)

- **to-be**
  -  InternalController 문법 오류 수정
```java
    @DeleteMapping
    public ResponseEntity<CommonDto<Void>> deleteUser(
        @RequestHeader(name = "X-User-Passport") String passport
    ) {
        userService.deleteUser(passport);
        return ResponseEntity.ok(CommonDto.ok(null, "사용자 삭제 완료"));
// 이 부분 중괄호 생략됨
```

## 참조
- resolve #87 
- [ET-61](https://challduck.atlassian.net/jira/software/projects/ET/boards/36?selectedIssue=ET-61)

## 코멘트

- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)