### PR TITLE
[ET-140] yml service 이름 수정 및 gateway macos silicon 의존성 추가

### DIFF
--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   config:
     import: optional:file:.env[.properties]
   application:
-    name: admin
+    name: admin-service
   kafka:
     bootstrap-servers: ${KAFKA_HOST}:${KAFKA_PORT}
   jpa:

--- a/concert/src/main/resources/application.yml
+++ b/concert/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   application:
-    name: concert
+    name: concert-service
   config:
     import: optional:file:.env[.properties]
   kafka:
@@ -10,7 +10,7 @@ spring:
       ddl-auto: update
     database: postgresql
     database-platform: org.hibernate.dialect.PostgreSQLDialect
-    show-sql: true
+  #    show-sql: true
   jackson:
     property-naming-strategy: SNAKE_CASE
   datasource:

--- a/gateway/build.gradle
+++ b/gateway/build.gradle
@@ -57,6 +57,9 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    runtimeOnly 'io.netty:netty-resolver-dns-native-macos:4.1.104.Final:osx-aarch_64' // MacOS Silicon 라이브러리 누락 문제
+
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/venue/src/main/resources/application.yml
+++ b/venue/src/main/resources/application.yml
@@ -2,7 +2,7 @@ server:
   port: 18086
 spring:
   application:
-    name: venue
+    name: venue-service
   config:
     import: optional:file:.env[.properties]
   data:
@@ -66,7 +66,7 @@ management:
     sampling:
       probability: ${ZIPKIN_SAMPLING_PROBABILITY:1.0}
 
-api :
+api:
   connection-timeout: 3000
   read-timeout: 120000
   max-buffer-size-MB: 300


### PR DESCRIPTION
## 변경 타입

- [ ] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 테스트 항목

- [x] 코드가 의도한 대로 동작하는지 테스트 완료
- [x] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음

## 변경 내용

- **as-is**
    - (변경 전 설명을 여기에 작성)

- **to-be**
    - (변경 후 설명을 여기에 작성)

## 참조

[ET-140](https://challduck.atlassian.net/jira/software/projects/ET/boards/36?selectedIssue=ET-140)

## 코멘트

- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 여러 서비스의 애플리케이션 이름을 "-service" 접미사로 변경하였습니다.
  - gateway 서비스에 MacOS Silicon(ARM) 지원을 위한 네이티브 라이브러리 의존성을 추가하였습니다.
  - venue 서비스 설정 파일의 일부 불필요한 공백을 수정하였습니다.
  - concert 서비스에서 SQL 로그 출력 설정을 비활성화하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->