### PR TITLE
[ET-134] feat(coupon): coupon repository 구현 #229

### DIFF
--- a/coupon/src/main/java/com/earlybird/ticket/coupon/domain/CouponRepository.java
+++ b/coupon/src/main/java/com/earlybird/ticket/coupon/domain/CouponRepository.java
@@ -15,5 +15,5 @@ public interface CouponRepository {
 
     Optional<Coupon> findByCouponId(UUID uuid);
 
-    CouponResult findAllByCoupon();
+    CouponResult findAllCoupon();
 }

--- a/coupon/src/main/java/com/earlybird/ticket/coupon/domain/CouponRepository.java
+++ b/coupon/src/main/java/com/earlybird/ticket/coupon/domain/CouponRepository.java
@@ -1,0 +1,19 @@
+package com.earlybird.ticket.coupon.domain;
+
+import com.earlybird.ticket.coupon.application.event.dto.CouponCreatePayload;
+import com.earlybird.ticket.coupon.domain.dto.CouponResult;
+import com.earlybird.ticket.coupon.domain.dto.UserCouponResult;
+import com.earlybird.ticket.coupon.domain.entity.Coupon;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CouponRepository {
+
+    UserCouponResult findByUserId(Long userId);
+
+    Coupon save(CouponCreatePayload payload);
+
+    Optional<Coupon> findByCouponId(UUID uuid);
+
+    CouponResult findAllByCoupon();
+}

--- a/coupon/src/main/java/com/earlybird/ticket/coupon/domain/dto/CouponResult.java
+++ b/coupon/src/main/java/com/earlybird/ticket/coupon/domain/dto/CouponResult.java
@@ -1,0 +1,29 @@
+package com.earlybird.ticket.coupon.domain.dto;
+
+import com.earlybird.ticket.coupon.domain.constant.CouponType;
+import com.earlybird.ticket.coupon.domain.entity.Coupon;
+import java.util.List;
+import java.util.UUID;
+
+public record CouponResult(
+        List<CouponResults> couponResults
+) {
+
+    public static CouponResult of(List<Coupon> result) {
+        return new CouponResult(result.stream().map((coupon) -> new CouponResults(
+                coupon.getCouponId(),
+                coupon.getCouponName(),
+                coupon.getCouponType(),
+                coupon.getDiscountRate()
+        )).toList());
+    }
+
+    public record CouponResults(
+            UUID couponId,
+            String couponName,
+            CouponType couponType,
+            Integer discountRate
+    ) {
+
+    }
+}

--- a/coupon/src/main/java/com/earlybird/ticket/coupon/domain/dto/UserCouponResult.java
+++ b/coupon/src/main/java/com/earlybird/ticket/coupon/domain/dto/UserCouponResult.java
@@ -1,0 +1,48 @@
+package com.earlybird.ticket.coupon.domain.dto;
+
+import com.earlybird.ticket.coupon.domain.constant.CouponType;
+import com.earlybird.ticket.coupon.domain.constant.CouponUsageStatus;
+import com.earlybird.ticket.coupon.domain.entity.UserCoupon;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+
+public record UserCouponResult(
+        List<UserCouponResults> userCouponQueries
+) {
+
+    public static UserCouponResult of(
+            List<UserCoupon> result
+    ) {
+        return new UserCouponResult(
+                result.stream().map((userCoupon) ->
+                                            UserCouponResults.builder()
+                                                    .couponId(
+                                                            userCoupon.getCoupon()
+                                                                    .getCouponId())
+                                                    .userCouponId(
+                                                            userCoupon.getUserCouponId())
+                                                    .couponName(
+                                                            userCoupon.getCouponName())
+                                                    .couponType(
+                                                            userCoupon.getCouponType())
+                                                    .discountRate(
+                                                            userCoupon.getDiscountRate())
+                                                    .usageStatus(
+                                                            userCoupon.getUsageStatus())
+                                                    .build()
+                ).toList());
+    }
+
+    @Builder
+    public record UserCouponResults(
+            UUID couponId,
+            UUID userCouponId,
+            String couponName,
+            CouponType couponType,
+            Integer discountRate,
+            CouponUsageStatus usageStatus
+    ) {
+
+    }
+}

--- a/coupon/src/main/java/com/earlybird/ticket/coupon/infrastructure/repository/CouponJpaRepository.java
+++ b/coupon/src/main/java/com/earlybird/ticket/coupon/infrastructure/repository/CouponJpaRepository.java
@@ -1,0 +1,9 @@
+package com.earlybird.ticket.coupon.infrastructure.repository;
+
+import com.earlybird.ticket.coupon.domain.entity.Coupon;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponJpaRepository extends JpaRepository<Coupon, UUID> {
+
+}

--- a/coupon/src/main/java/com/earlybird/ticket/coupon/infrastructure/repository/CouponQueryDslRepository.java
+++ b/coupon/src/main/java/com/earlybird/ticket/coupon/infrastructure/repository/CouponQueryDslRepository.java
@@ -1,0 +1,11 @@
+package com.earlybird.ticket.coupon.infrastructure.repository;
+
+import com.earlybird.ticket.coupon.domain.dto.CouponResult;
+import com.earlybird.ticket.coupon.domain.dto.UserCouponResult;
+
+public interface CouponQueryDslRepository {
+
+    UserCouponResult findAllByUserId(Long userId);
+
+    CouponResult findAllByCouponId();
+}

--- a/coupon/src/main/java/com/earlybird/ticket/coupon/infrastructure/repository/CouponQueryDslRepository.java
+++ b/coupon/src/main/java/com/earlybird/ticket/coupon/infrastructure/repository/CouponQueryDslRepository.java
@@ -7,5 +7,5 @@ public interface CouponQueryDslRepository {
 
     UserCouponResult findAllByUserId(Long userId);
 
-    CouponResult findAllByCouponId();
+    CouponResult findAllCoupons();
 }

--- a/coupon/src/main/java/com/earlybird/ticket/coupon/infrastructure/repository/CouponQueryDslRepositoryImpl.java
+++ b/coupon/src/main/java/com/earlybird/ticket/coupon/infrastructure/repository/CouponQueryDslRepositoryImpl.java
@@ -1,0 +1,62 @@
+package com.earlybird.ticket.coupon.infrastructure.repository;
+
+import static com.earlybird.ticket.coupon.domain.entity.QCoupon.coupon;
+import static com.earlybird.ticket.coupon.domain.entity.QUserCoupon.userCoupon;
+
+import com.earlybird.ticket.coupon.domain.dto.CouponResult;
+import com.earlybird.ticket.coupon.domain.dto.UserCouponResult;
+import com.earlybird.ticket.coupon.domain.entity.Coupon;
+import com.earlybird.ticket.coupon.domain.entity.UserCoupon;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CouponQueryDslRepositoryImpl implements CouponQueryDslRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+
+    @Override
+    public UserCouponResult findAllByUserId(Long userId) {
+
+        List<UserCoupon> result = jpaQueryFactory
+                .select(Projections.constructor(
+                        UserCoupon.class,
+                        userCoupon.userCouponId,
+                        userCoupon.coupon,
+                        userCoupon.userId,
+                        userCoupon.couponType,
+                        userCoupon.discountRate,
+                        userCoupon.couponName,
+                        userCoupon.usageStatus
+                ))
+                .from(userCoupon)
+                .join(userCoupon.coupon, coupon)
+                .where(userCoupon.userId.eq(userId))
+                .fetch();
+
+        return UserCouponResult.of(result);
+    }
+
+    @Override
+    public CouponResult findAllByCouponId() {
+
+        List<Coupon> result = jpaQueryFactory
+                .select(Projections.constructor(
+                        Coupon.class,
+                        coupon.couponId,
+                        coupon.couponType,
+                        coupon.discountRate,
+                        coupon.couponName
+                ))
+                .from(coupon)
+                .where(coupon.deletedAt.isNull())
+                .fetch();
+
+        return CouponResult.of(result);
+    }
+}

--- a/coupon/src/main/java/com/earlybird/ticket/coupon/infrastructure/repository/CouponQueryDslRepositoryImpl.java
+++ b/coupon/src/main/java/com/earlybird/ticket/coupon/infrastructure/repository/CouponQueryDslRepositoryImpl.java
@@ -19,7 +19,6 @@ public class CouponQueryDslRepositoryImpl implements CouponQueryDslRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
-
     @Override
     public UserCouponResult findAllByUserId(Long userId) {
 
@@ -43,7 +42,7 @@ public class CouponQueryDslRepositoryImpl implements CouponQueryDslRepository {
     }
 
     @Override
-    public CouponResult findAllByCouponId() {
+    public CouponResult findAllCoupons() {
 
         List<Coupon> result = jpaQueryFactory
                 .select(Projections.constructor(

--- a/coupon/src/main/java/com/earlybird/ticket/coupon/infrastructure/repository/CouponRepositoryImpl.java
+++ b/coupon/src/main/java/com/earlybird/ticket/coupon/infrastructure/repository/CouponRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.earlybird.ticket.coupon.infrastructure.repository;
+
+import com.earlybird.ticket.coupon.application.event.dto.CouponCreatePayload;
+import com.earlybird.ticket.coupon.domain.CouponRepository;
+import com.earlybird.ticket.coupon.domain.dto.CouponResult;
+import com.earlybird.ticket.coupon.domain.dto.UserCouponResult;
+import com.earlybird.ticket.coupon.domain.entity.Coupon;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CouponRepositoryImpl implements CouponRepository {
+
+    private final CouponQueryDslRepository couponQueryDslRepository;
+    private final CouponJpaRepository couponJpaRepository;
+
+    @Override
+    public UserCouponResult findByUserId(Long userId) {
+        return couponQueryDslRepository.findAllByUserId(userId);
+    }
+
+    @Override
+    public Coupon save(CouponCreatePayload payload) {
+        return couponJpaRepository.save(payload.toEntity());
+    }
+
+    @Override
+    public Optional<Coupon> findByCouponId(UUID uuid) {
+        return couponJpaRepository.findById(uuid);
+    }
+
+    @Override
+    public CouponResult findAllByCoupon() {
+        return couponQueryDslRepository.findAllByCouponId();
+    }
+
+}

--- a/coupon/src/main/java/com/earlybird/ticket/coupon/infrastructure/repository/CouponRepositoryImpl.java
+++ b/coupon/src/main/java/com/earlybird/ticket/coupon/infrastructure/repository/CouponRepositoryImpl.java
@@ -33,8 +33,8 @@ public class CouponRepositoryImpl implements CouponRepository {
     }
 
     @Override
-    public CouponResult findAllByCoupon() {
-        return couponQueryDslRepository.findAllByCouponId();
+    public CouponResult findAllCoupon() {
+        return couponQueryDslRepository.findAllCoupons();
     }
 
 }


### PR DESCRIPTION
## 변경 타입

- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 테스트 항목

- [x] 코드가 의도한 대로 동작하는지 테스트 완료
- [ ] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음

## 변경 내용

- **as-is**
    - (변경 전 설명을 여기에 작성)

- **to-be**
    - Coupon Jpa Repository 구현
    - Coupon QueryDSL Repository 구현
    - Coupon Repositroy Interface 및 Impl 구현
    - result dto 구현

## 참조

[ET-134](https://challduck.atlassian.net/jira/software/projects/ET/boards/36?selectedIssue=ET-134)

## 코멘트

- resolve #229  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 쿠폰 및 사용자 쿠폰 정보를 조회하고 저장할 수 있는 기능이 추가되었습니다.
    - 사용자별 쿠폰 목록과 전체 쿠폰 목록을 확인할 수 있습니다.
    - 쿠폰 생성 및 개별 쿠폰 상세 조회가 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->