### PR TITLE
[ET-142] refactor(all) : Event 필드명 eventType으로 일괄 수정

### DIFF
--- a/admin/src/main/java/com/earlybird/ticket/admin/application/event/Event.java
+++ b/admin/src/main/java/com/earlybird/ticket/admin/application/event/Event.java
@@ -7,13 +7,13 @@ import lombok.Getter;
 @Getter
 public class Event<T extends EventPayload> {
 
-    private EventType type;
+    private EventType eventType;
     private T payload;
     private String timestamp;
 
     public static Event<EventPayload> of(EventType type, EventPayload payload, String timestamp) {
         Event<EventPayload> event = new Event<>();
-        event.type = type;
+        event.eventType = type;
         event.payload = payload;
         event.timestamp = timestamp;
         return event;
@@ -25,8 +25,8 @@ public class Event<T extends EventPayload> {
             return null;
         }
         Event<EventPayload> event = new Event<>();
-        event.type = EventType.from(eventRaw.getType());
-        event.payload = DataUtil.deserialize(eventRaw.getPayload(), event.type.getPayloadClass());
+        event.eventType = EventType.from(eventRaw.getEventType());
+        event.payload = DataUtil.deserialize(eventRaw.getPayload(), event.eventType.getPayloadClass());
         event.timestamp = eventRaw.getTimestamp();
         return event;
     }
@@ -38,7 +38,7 @@ public class Event<T extends EventPayload> {
     @Getter
     private static class EventRaw {
 
-        private String type;
+        private String eventType;
         private Object payload;
         private String timestamp;
     }

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -24,4 +24,4 @@ server:
 eureka:
   client:
     service-url:
-      defaultZone: http://${EUREKA_HOST:localhost}:${EUREKA_PORT:8761}/eureka
+      defaultZone: http://${EUREKA_HOST:localhost}:${EUREKA_PORT:18080}/eureka

--- a/concert/src/main/java/com/earlybird/ticket/concert/application/event/Event.java
+++ b/concert/src/main/java/com/earlybird/ticket/concert/application/event/Event.java
@@ -7,13 +7,13 @@ import lombok.Getter;
 @Getter
 public class Event<T extends EventPayload> {
 
-    private EventType type;
+    private EventType eventType;
     private T payload;
     private String timestamp;
 
     public static Event<EventPayload> of(EventType type, EventPayload payload, String timestamp) {
         Event<EventPayload> event = new Event<>();
-        event.type = type;
+        event.eventType = type;
         event.payload = payload;
         event.timestamp = timestamp;
         return event;
@@ -25,8 +25,8 @@ public class Event<T extends EventPayload> {
             return null;
         }
         Event<EventPayload> event = new Event<>();
-        event.type = EventType.from(eventRaw.getType());
-        event.payload = DataUtil.deserialize(eventRaw.getPayload(), event.type.getPayloadClass());
+        event.eventType = EventType.from(eventRaw.getEventType());
+        event.payload = DataUtil.deserialize(eventRaw.getPayload(), event.eventType.getPayloadClass());
         event.timestamp = eventRaw.getTimestamp();
         return event;
     }
@@ -38,7 +38,7 @@ public class Event<T extends EventPayload> {
     @Getter
     private static class EventRaw {
 
-        private String type;
+        private String eventType;
         private Object payload;
         private String timestamp;
     }

--- a/concert/src/main/resources/application.yml
+++ b/concert/src/main/resources/application.yml
@@ -24,4 +24,4 @@ server:
 eureka:
   client:
     service-url:
-      defaultZone: http://${EUREKA_HOST:localhost}:${EUREKA_PORT:8761}/eureka
+      defaultZone: http://${EUREKA_HOST:localhost}:${EUREKA_PORT:18080}/eureka

--- a/reservation/src/main/resources/application.yml
+++ b/reservation/src/main/resources/application.yml
@@ -58,7 +58,7 @@ eureka:
     fetch-registry: true
     register-with-eureka: true
     service-url:
-      defaultZone: http://${EUREKA_HOST:localhost}:${EUREKA_PORT:18088}/eureka
+      defaultZone: http://${EUREKA_HOST:localhost}:${EUREKA_PORT:18080}/eureka
     registry-fetch-interval-seconds: 10
   instance:
     lease-renewal-interval-in-seconds: 10


### PR DESCRIPTION
## 변경 타입

- [ ] 신규 기능 추가/수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 테스트 항목

- [x] 코드가 의도한 대로 동작하는지 테스트 완료
- [ ] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음

## 변경 내용

- **as-is**
    - (변경 전 설명을 여기에 작성)

- **to-be**
    - Eureka 기본 포트 18080으로 수정
    - producer와 consumer 쪽에서 받는 eventType에 대한 필드명이 달랐던 문제가 있었고 `eventType`으로 통일

## 참조

[ET-](https://challduck.atlassian.net/jira/software/projects/ET/boards/36?selectedIssue=ET-)

## 코멘트

- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- 이벤트 관련 필드명이 일관성 있게 `type`에서 `eventType`으로 변경되었습니다.

- **Chores**
	- Eureka 서버 연결 포트가 기본 8761/18088에서 18080으로 변경되어 서비스 등록 및 통신에 사용되는 엔드포인트가 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->