### PR TITLE
[ET108] feat(payment) : 결제 취소 API 연동

### DIFF
--- a/payment/src/main/java/com/earlybird/ticket/payment/application/service/PaymentClient.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/application/service/PaymentClient.java
@@ -1,10 +1,13 @@
 package com.earlybird.ticket.payment.application.service;
 
 import com.earlybird.ticket.payment.application.service.dto.command.ConfirmPaymentCommand;
+import com.earlybird.ticket.payment.application.service.dto.command.UpdatePaymentCancelCommand;
 import com.earlybird.ticket.payment.application.service.dto.command.UpdatePaymentCommand;
 import java.util.UUID;
 
 public interface PaymentClient {
 
     UpdatePaymentCommand confirmPayment(ConfirmPaymentCommand command, UUID paymentId);
+
+    UpdatePaymentCancelCommand cancelPayment(String paymentKey, UUID reservationId);
 }

--- a/payment/src/main/java/com/earlybird/ticket/payment/application/service/PaymentServiceImpl.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/application/service/PaymentServiceImpl.java
@@ -8,6 +8,7 @@ import com.earlybird.ticket.payment.application.TemporaryStore;
 import com.earlybird.ticket.payment.application.event.dto.request.PaymentSuccessEvent;
 import com.earlybird.ticket.payment.application.service.dto.command.ConfirmPaymentCommand;
 import com.earlybird.ticket.payment.application.service.dto.command.CreatePaymentCommand;
+import com.earlybird.ticket.payment.application.service.dto.command.UpdatePaymentCancelCommand;
 import com.earlybird.ticket.payment.application.service.dto.query.FindPaymentQuery;
 import com.earlybird.ticket.payment.application.service.exception.PaymentAmountDoesNotMatchException;
 import com.earlybird.ticket.payment.application.service.exception.PaymentNotFoundException;
@@ -110,9 +111,17 @@ public class PaymentServiceImpl implements PaymentService {
     }
 
     @Override
+    @Transactional
     public void cancelPayment(UUID paymentId) {
         // TODO : 결제 취소 요청
-        // paymentClient.cancelPayment();
+        Payment payment = paymentRepository.findByPaymentId(paymentId)
+            .orElseThrow(PaymentNotFoundException::new);
+
+        Payment cancelPayment = paymentClient.cancelPayment(
+                payment.getPaymentKey(), payment.getReservationId())
+            .toCancelPayment();
+
+        payment.cancelPayment(cancelPayment);
     }
 
     private void validatePaymentAmount(Payment payment, BigDecimal amount) {

--- a/payment/src/main/java/com/earlybird/ticket/payment/application/service/TestPaymentServiceImpl.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/application/service/TestPaymentServiceImpl.java
@@ -115,9 +115,24 @@ public class TestPaymentServiceImpl implements PaymentService {
     }
 
     @Override
+    @Transactional
     public void cancelPayment(UUID paymentId) {
-        // TODO : 결제 취소 요청
-        // paymentClient.cancelPayment();
+        Payment payment = paymentRepository.findByPaymentId(paymentId)
+            .orElseThrow(PaymentNotFoundException::new);
+
+        Random random = new Random();
+        // WebClient 호출 시간 모방
+        try {
+            Thread.sleep(random.nextInt(1000));
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        Payment mockDelete = Payment.builder()
+            .reservationId(payment.getReservationId())
+            .status(PaymentStatus.CANCELED)
+            .build();
+
+        payment.cancelPayment(mockDelete);
     }
 
     private void validatePaymentAmount(Payment payment, BigDecimal amount) {

--- a/payment/src/main/java/com/earlybird/ticket/payment/application/service/dto/command/UpdatePaymentCancelCommand.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/application/service/dto/command/UpdatePaymentCancelCommand.java
@@ -1,0 +1,20 @@
+package com.earlybird.ticket.payment.application.service.dto.command;
+
+import com.earlybird.ticket.payment.domain.entity.Payment;
+import com.earlybird.ticket.payment.domain.entity.constant.PaymentStatus;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record UpdatePaymentCancelCommand(
+    PaymentStatus status,
+    UUID reservationId
+) {
+
+    public Payment toCancelPayment() {
+        return Payment.builder()
+            .status(status)
+            .reservationId(reservationId)
+            .build();
+    }
+}

--- a/payment/src/main/java/com/earlybird/ticket/payment/application/service/exception/PaymentCancelException.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/application/service/exception/PaymentCancelException.java
@@ -1,0 +1,10 @@
+package com.earlybird.ticket.payment.application.service.exception;
+
+import com.earlybird.ticket.common.entity.constant.Code;
+
+public class PaymentCancelException extends AbstractPaymentException {
+
+    public PaymentCancelException() {
+        super("결제 취소 중 문제가 발생했습니다. 다시 시도해주세요.", Code.CONFLICT);
+    }
+}

--- a/payment/src/main/java/com/earlybird/ticket/payment/domain/entity/Payment.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/domain/entity/Payment.java
@@ -1,6 +1,7 @@
 package com.earlybird.ticket.payment.domain.entity;
 
 import com.earlybird.ticket.common.entity.BaseEntity;
+import com.earlybird.ticket.payment.application.service.exception.PaymentNotFoundException;
 import com.earlybird.ticket.payment.domain.entity.constant.PaymentMethod;
 import com.earlybird.ticket.payment.domain.entity.constant.PaymentStatus;
 import jakarta.persistence.*;
@@ -90,6 +91,14 @@ public class Payment extends BaseEntity {
         this.method = receipt.method;
         this.status = receipt.status;
         this.update(this.userId);
+    }
+
+    public void cancelPayment(Payment canceled) {
+        if (!this.getReservationId().equals(canceled.reservationId)) {
+            throw new PaymentNotFoundException();
+        }
+        this.status = canceled.status;
+        this.delete(this.userId);
     }
 
 }

--- a/payment/src/main/java/com/earlybird/ticket/payment/domain/entity/constant/PaymentStatus.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/domain/entity/constant/PaymentStatus.java
@@ -11,7 +11,9 @@ public enum PaymentStatus {
     WAIT_FOR_DEPOSIT(Status.WAITING_FOR_DEPOSIT),
     DONE(Status.DONE),
     ABORTED(Status.ABORTED),
-    EXPIRED(Status.EXPIRED);
+    EXPIRED(Status.EXPIRED),
+    CANCELED(Status.CANCELED),
+    ;
 
     private final String value;
 
@@ -32,5 +34,7 @@ public enum PaymentStatus {
         public static final String ABORTED = "ABORTED";
         // 10분 이후에는 좌석 반환과 함께 결제 실패
         public static final String EXPIRED = "EXPIRED";
+
+        public static final String CANCELED = "CANCELED";
     }
 }

--- a/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/client/dto/response/ProcessPaymentCancelClientResponse.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/client/dto/response/ProcessPaymentCancelClientResponse.java
@@ -1,0 +1,21 @@
+package com.earlybird.ticket.payment.infrastructure.client.dto.response;
+
+import com.earlybird.ticket.payment.application.service.dto.command.UpdatePaymentCancelCommand;
+import com.earlybird.ticket.payment.domain.entity.constant.PaymentStatus;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record ProcessPaymentCancelClientResponse(
+    PaymentStatus status,
+    @JsonProperty("orderId") UUID reservationId
+) {
+
+    public UpdatePaymentCancelCommand toUpdatePaymentCancelCommand() {
+        return UpdatePaymentCancelCommand.builder()
+            .status(status)
+            .reservationId(reservationId)
+            .build();
+    }
+}

--- a/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/client/dto/response/ProcessPaymentConfirmClientResponse.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/client/dto/response/ProcessPaymentConfirmClientResponse.java
@@ -6,7 +6,7 @@ import com.earlybird.ticket.payment.domain.entity.constant.PaymentStatus;
 import lombok.Builder;
 
 @Builder
-public record ConfirmPaymentMethodClientResponse(
+public record ProcessPaymentConfirmClientResponse(
     String method,
     String status,
     String paymentKey

--- a/payment/src/main/java/com/earlybird/ticket/payment/presentation/PaymentExternalController.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/presentation/PaymentExternalController.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -40,7 +41,6 @@ public class PaymentExternalController {
     public ResponseEntity<CommonDto<FindPaymentResponse>> findPayment(
         @PathVariable(name = "paymentId") UUID paymentId
     ) {
-        // TODO : Redis 결제 타임아웃 검증
         FindPaymentQuery payment = paymentService.findPayment(paymentId);
         return ResponseEntity.ok(CommonDto.ok(FindPaymentResponse.of(payment), "조회 성공"));
     }
@@ -49,10 +49,18 @@ public class PaymentExternalController {
     public ResponseEntity<CommonDto<Void>> confirmPayment(
         @RequestBody ConfirmPaymentRequest paymentRequest
     ) {
-        // TODO : Redis 결제 타임아웃 검증
         log.info("confirmPayment = {}", paymentRequest);
         paymentService.confirmPayment(paymentRequest.toConfirmPaymentCommand());
 
         return ResponseEntity.ok(CommonDto.ok(null, "결제 확정 성공"));
+    }
+
+    // event로 변경 예정
+    @DeleteMapping("/{paymentId}")
+    public ResponseEntity<CommonDto<Void>> cancelPayment(
+        @PathVariable(name = "paymentId") UUID paymentId
+    ) {
+        paymentService.cancelPayment(paymentId);
+        return ResponseEntity.ok(CommonDto.ok(null, "결제 취소 성공"));
     }
 }


### PR DESCRIPTION
## 변경 타입

- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 테스트 항목

- [x] 코드가 의도한 대로 동작하는지 테스트 완료
- [ ] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음

## 변경 내용

- **as-is**
    - (변경 전 설명을 여기에 작성)

- **to-be**
    - 토스페이 결제 취소 API 연동
    - 테스트 서비스도 결제 취소 기능 추가

## 참조
- resolve #237 
- [ET-108](https://challduck.atlassian.net/jira/software/projects/ET/boards/36?selectedIssue=ET-108)

## 코멘트

- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 결제 취소 기능이 추가되어 사용자가 결제를 취소할 수 있습니다.
    - 결제 취소를 위한 새로운 API 엔드포인트(DELETE /{paymentId})가 제공됩니다.

- **버그 수정**
    - 결제 관련 일부 주석 및 불필요한 코드가 정리되었습니다.

- **기타**
    - 결제 상태에 "CANCELED"가 추가되어 취소 상태를 명확하게 확인할 수 있습니다.
    - 결제 취소 시 발생하는 예외 처리가 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->