### PR TITLE
[ET-145] refactor(concert): toEntity 메서드 내 엔티티를 분리하여 저장하도록 수정 #239

### DIFF
--- a/concert/src/main/java/com/earlybird/ticket/concert/application/dto/RegisterConcertCommand.java
+++ b/concert/src/main/java/com/earlybird/ticket/concert/application/dto/RegisterConcertCommand.java
@@ -29,8 +29,7 @@ public record RegisterConcertCommand(
 ) {
 
     public Concert toEntity() {
-
-        return Concert.builder()
+        Concert concert = Concert.builder()
                 .hallId(hallId)
                 .venueId(venueId)
                 .concertName(concertName())
@@ -41,30 +40,34 @@ public record RegisterConcertCommand(
                 .runningTime(runningTime())
                 .sellerId(sellerId())
                 .priceInfo(priceInfo())
-                .concertSequences(concertSequences()
-                                          .stream()
-                                          .map(seq -> ConcertSequence.builder()
-                                                  .sequenceStartDate(seq.sequenceStartDate())
-                                                  .sequenceEndDate(seq.sequenceEndDate())
-                                                  .ticketSaleStartDate(seq.ticketSaleStartDate())
-                                                  .ticketSaleEndDate(seq.ticketSaleEndDate())
-                                                  .concertStatus(seq.status())
-                                                  .build()
-                                          )
-                                          .toList()
-                )
-                .seatInstanceInfo(seatInstanceInfoList()
-                                          .stream()
-                                          .map(info -> SeatInstanceInfo.builder()
-                                                  .section(info.section())
-                                                  .grade(info.grade())
-                                                  .price(info.price())
-                                                  .build()
-                                          )
-                                          .toList()
-                )
                 .build();
+
+        List<ConcertSequence> sequences = concertSequences().stream()
+                .map(seq -> ConcertSequence.builder()
+                        .sequenceStartDate(seq.sequenceStartDate())
+                        .sequenceEndDate(seq.sequenceEndDate())
+                        .ticketSaleStartDate(seq.ticketSaleStartDate())
+                        .ticketSaleEndDate(seq.ticketSaleEndDate())
+                        .concertStatus(seq.status())
+                        .concert(concert)
+                        .build())
+                .toList();
+
+        List<SeatInstanceInfo> seats = seatInstanceInfoList().stream()
+                .map(info -> SeatInstanceInfo.builder()
+                        .concert(concert)
+                        .section(info.section())
+                        .grade(info.grade())
+                        .price(info.price())
+                        .build())
+                .toList();
+
+        concert.addConcertSequences(sequences);
+        concert.addSeatInstanceInfo(seats);
+
+        return concert;
     }
+
 
     @Builder
     public record SeatInstanceInfoCommand(

--- a/concert/src/main/java/com/earlybird/ticket/concert/domain/Concert.java
+++ b/concert/src/main/java/com/earlybird/ticket/concert/domain/Concert.java
@@ -142,4 +142,12 @@ public class Concert extends BaseEntity {
                 })
                 .forEach(concertSequences::add);
     }
+
+    public void addSeatInstanceInfo(List<SeatInstanceInfo> seats) {
+        this.seatInstanceInfo.addAll(seats);
+    }
+
+    public void addConcertSequences(List<ConcertSequence> sequences) {
+        this.concertSequences.addAll(sequences);
+    }
 }


### PR DESCRIPTION
## 변경 타입

- [ ] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 테스트 항목

- [ ] 코드가 의도한 대로 동작하는지 테스트 완료
- [ ] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음

## 변경 내용

- **as-is**
    - builder 패턴으로 한번에 entity 생성하였음.

- **to-be**
    - toEntity 메서드 내 엔티티를 분리하여 저장하도록 수정
    - concert entity내 하위 엔티티 저장 메서드 구현


## 참조

[ET-145](https://challduck.atlassian.net/jira/software/projects/ET/boards/36?selectedIssue=ET-145)

## 코멘트

- resolve #239 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- 콘서트와 관련된 시퀀스 및 좌석 정보의 내부 연관 관계 설정 방식이 개선되어, 데이터의 일관성과 관리가 향상되었습니다.  
- **New Features**
	- 콘서트에 시퀀스 및 좌석 정보를 추가할 수 있는 기능이 확장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->