### PR TITLE
[ET-152] refactor(concert) : concert 회차 정보 엔티티 생성 로직 수정, 발행시 직렬화 Stri…

### DIFF
--- a/concert/src/main/java/com/earlybird/ticket/concert/domain/Concert.java
+++ b/concert/src/main/java/com/earlybird/ticket/concert/domain/Concert.java
@@ -3,24 +3,17 @@ package com.earlybird.ticket.concert.domain;
 import com.earlybird.ticket.common.entity.BaseEntity;
 import com.earlybird.ticket.concert.domain.constant.ConcertStatus;
 import com.earlybird.ticket.concert.domain.constant.Genre;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 @Getter
 @Entity
@@ -61,13 +54,18 @@ public class Concert extends BaseEntity {
     private List<SeatInstanceInfo> seatInstanceInfo = new ArrayList<>();
 
     @Builder
-    public Concert(
-            String concertName, String entertainerName, LocalDateTime startDate,
-            LocalDateTime endDate, Genre genre, Integer runningTime, Long sellerId,
-            String priceInfo,
-            List<SeatInstanceInfo> seatInstanceInfo,
-            List<ConcertSequence> concertSequences, UUID hallId, UUID venueId
-    ) {
+    public Concert(String concertName,
+                   String entertainerName,
+                   LocalDateTime startDate,
+                   LocalDateTime endDate,
+                   Genre genre,
+                   Integer runningTime,
+                   Long sellerId,
+                   String priceInfo,
+                   List<SeatInstanceInfo> seatInstanceInfo,
+                   List<ConcertSequence> concertSequences,
+                   UUID hallId,
+                   UUID venueId) {
         this.concertName = concertName;
         this.entertainerName = entertainerName;
         this.startDate = startDate;
@@ -82,27 +80,23 @@ public class Concert extends BaseEntity {
         this.venueId = venueId;
     }
 
-    public void deleteConcertSequence(
-            Long userId,
-            UUID concertSequenceId
-    ) {
+    public void deleteConcertSequence(Long userId,
+                                      UUID concertSequenceId) {
         for (ConcertSequence concertSequence : this.concertSequences) {
             if (concertSequence.getDeletedAt() == null && concertSequence.getConcertSequenceId()
-                    .equals(concertSequenceId)) {
+                                                                         .equals(concertSequenceId)) {
                 concertSequence.delete(userId);
             }
         }
     }
 
-    public void updateConcert(
-            String concertName,
-            String entertainerName,
-            LocalDateTime startDate,
-            LocalDateTime endDate,
-            Genre genre,
-            Integer runningTime,
-            String priceInfo
-    ) {
+    public void updateConcert(String concertName,
+                              String entertainerName,
+                              LocalDateTime startDate,
+                              LocalDateTime endDate,
+                              Genre genre,
+                              Integer runningTime,
+                              String priceInfo) {
         this.concertName = concertName;
         this.entertainerName = entertainerName;
         this.startDate = startDate;
@@ -117,37 +111,39 @@ public class Concert extends BaseEntity {
     }
 
     @Builder(builderMethodName = "updateConcertSequenceBuilder")
-    public void updateConcertSequence(
-            UUID concertSequenceId,
-            LocalDateTime sequenceStartDate,
-            LocalDateTime sequenceEndDate,
-            LocalDateTime ticketSaleStartDate,
-            LocalDateTime ticketSaleEndDate,
-            ConcertStatus status
-    ) {
+    public void updateConcertSequence(UUID concertSequenceId,
+                                      LocalDateTime sequenceStartDate,
+                                      LocalDateTime sequenceEndDate,
+                                      LocalDateTime ticketSaleStartDate,
+                                      LocalDateTime ticketSaleEndDate,
+                                      ConcertStatus status) {
 
         concertSequences.stream()
-                .map(concertSequence -> {
-                    if (concertSequence.getConcertSequenceId()
-                            .equals(concertSequenceId)) {
-                        concertSequence.update(
-                                sequenceStartDate,
-                                sequenceEndDate,
-                                ticketSaleStartDate,
-                                ticketSaleEndDate,
-                                status
-                        );
-                    }
-                    return concertSequence;
-                })
-                .forEach(concertSequences::add);
-    }
-
-    public void addSeatInstanceInfo(List<SeatInstanceInfo> seats) {
-        this.seatInstanceInfo.addAll(seats);
+                        .map(concertSequence -> {
+                            if (concertSequence.getConcertSequenceId()
+                                               .equals(concertSequenceId)) {
+                                concertSequence.update(sequenceStartDate,
+                                                       sequenceEndDate,
+                                                       ticketSaleStartDate,
+                                                       ticketSaleEndDate,
+                                                       status);
+                            }
+                            return concertSequence;
+                        })
+                        .forEach(concertSequences::add);
     }
 
     public void addConcertSequences(List<ConcertSequence> sequences) {
+        if (this.concertSequences == null) {
+            this.concertSequences = new ArrayList<>();
+        }
         this.concertSequences.addAll(sequences);
+    }
+
+    public void addSeatInstanceInfo(List<SeatInstanceInfo> seats) {
+        if (this.seatInstanceInfo == null) {
+            this.seatInstanceInfo = new ArrayList<>();
+        }
+        this.seatInstanceInfo.addAll(seats);
     }
 }

--- a/concert/src/main/java/com/earlybird/ticket/concert/infrastructure/KafkaProducerConfig.java
+++ b/concert/src/main/java/com/earlybird/ticket/concert/infrastructure/KafkaProducerConfig.java
@@ -1,7 +1,5 @@
 package com.earlybird.ticket.concert.infrastructure;
 
-import java.util.HashMap;
-import java.util.Map;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -9,11 +7,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.kafka.support.serializer.JsonSerializer;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @EnableAsync
 @Configuration
@@ -26,17 +26,28 @@ public class KafkaProducerConfig {
     @Bean
     public KafkaTemplate<String, String> messageRelayKafkaTemplate() {
         Map<String, Object> configProps = new HashMap<>();
-        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
-        configProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
-        configProps.put(ProducerConfig.ACKS_CONFIG, "all");
-        configProps.put(ProducerConfig.RETRIES_CONFIG, 3);
-        configProps.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5);
-        configProps.put(ProducerConfig.BATCH_SIZE_CONFIG, 16384);
-        configProps.put(ProducerConfig.LINGER_MS_CONFIG, 1);
-        configProps.put(ProducerConfig.BUFFER_MEMORY_CONFIG, 33554432);
-        configProps.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "gzip");
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                        bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                        StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                        StringSerializer.class);
+        configProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG,
+                        true);
+        configProps.put(ProducerConfig.ACKS_CONFIG,
+                        "all");
+        configProps.put(ProducerConfig.RETRIES_CONFIG,
+                        3);
+        configProps.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION,
+                        5);
+        configProps.put(ProducerConfig.BATCH_SIZE_CONFIG,
+                        16384);
+        configProps.put(ProducerConfig.LINGER_MS_CONFIG,
+                        1);
+        configProps.put(ProducerConfig.BUFFER_MEMORY_CONFIG,
+                        33554432);
+        configProps.put(ProducerConfig.COMPRESSION_TYPE_CONFIG,
+                        "gzip");
         return new KafkaTemplate<>(new DefaultKafkaProducerFactory<>(configProps));
     }
 


### PR DESCRIPTION
…ng으로 수정

## 변경 타입

- [ ] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 테스트 항목

- [x] 코드가 의도한 대로 동작하는지 테스트 완료
- [ ] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음

## 변경 내용

- **as-is**
    - (변경 전 설명을 여기에 작성)

- **to-be**
    - concert 회차 정보 엔티티가 null일경우 빈 배열 생성
    - Kafka Producer 발행시 StringSerializer 사용

## 참조

[ET-1522](https://challduck.atlassian.net/jira/software/projects/ET/boards/36?selectedIssue=ET-152)

## 코멘트

- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 콘서트 시퀀스 및 좌석 인스턴스 정보 추가 시 발생할 수 있는 오류를 방지하기 위해 리스트가 null일 경우 자동으로 초기화됩니다.

- **기타**
  - Kafka 프로듀서의 메시지 값 직렬화 방식이 JSON에서 문자열로 변경되었습니다.
  - 코드 가독성을 높이기 위한 정렬 및 포맷 개선이 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->