### PR TITLE
[ET-160] refactor(reservation) : 예약 상태에 따른 reservation, reservationSe…

### DIFF
--- a/reservation/src/main/java/com/earlybird/ticket/reservation/application/handler/ConfirmSeatFailPayloadHandler.java
+++ b/reservation/src/main/java/com/earlybird/ticket/reservation/application/handler/ConfirmSeatFailPayloadHandler.java
@@ -4,10 +4,12 @@ import com.earlybird.ticket.common.entity.PassportDto;
 import com.earlybird.ticket.reservation.application.dto.response.SeatConfirmFailPayload;
 import com.earlybird.ticket.reservation.application.event.EventHandler;
 import com.earlybird.ticket.reservation.domain.entity.Event;
+import com.earlybird.ticket.reservation.domain.entity.Reservation;
 import com.earlybird.ticket.reservation.domain.entity.ReservationSeat;
 import com.earlybird.ticket.reservation.domain.entity.constant.EventType;
 import com.earlybird.ticket.reservation.domain.repository.ReservationSeatRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,7 +17,7 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-
+@Slf4j
 public class ConfirmSeatFailPayloadHandler implements EventHandler<SeatConfirmFailPayload> {
 
     private final ReservationSeatRepository reservationSeatRepository;
@@ -28,18 +30,18 @@ public class ConfirmSeatFailPayloadHandler implements EventHandler<SeatConfirmFa
 
         List<ReservationSeat> seatIntanceList = reservationSeatRepository.findAllByInstanceIdIn(payload.seatInstanceIdList());
         PassportDto passport = payload.passportDto();
+
         seatIntanceList.forEach(reservationSeat -> {
-            reservationSeat.getReservation()
-                           .delete(passport.getUserId());
+            log.info("Reservation 상태 -> CANCELLED 및 삭제 처리");
+            Reservation reservation = reservationSeat.getReservation();
+            reservation.updateStatusCancelled(passport.getUserId());
 
             //예약 좌석 상태 FREE로 수정
-            reservationSeat.updateStatusReserveFREE();
-            reservationSeat.delete(passport.getUserId());
+            reservationSeat.updateStatusFREE(passport.getUserId());
 
-            //TODO:: 좌석 반환 요청
-            //TODO:: 결제 취소 요청
+            //TODO:: 결제 취소 요청?
             //TODO:: 실패 알람 처리
-            //Code를 가지고 내용 보내기
+            //Payload의 Code를 가지고 내용 보내기
         });
     }
 

--- a/reservation/src/main/java/com/earlybird/ticket/reservation/application/handler/ConfirmSeatSuccessPayloadHandler.java
+++ b/reservation/src/main/java/com/earlybird/ticket/reservation/application/handler/ConfirmSeatSuccessPayloadHandler.java
@@ -3,6 +3,7 @@ package com.earlybird.ticket.reservation.application.handler;
 import com.earlybird.ticket.reservation.application.dto.response.SeatConfirmSuccessPayload;
 import com.earlybird.ticket.reservation.application.event.EventHandler;
 import com.earlybird.ticket.reservation.domain.entity.Event;
+import com.earlybird.ticket.reservation.domain.entity.Reservation;
 import com.earlybird.ticket.reservation.domain.entity.ReservationSeat;
 import com.earlybird.ticket.reservation.domain.entity.constant.EventType;
 import com.earlybird.ticket.reservation.domain.repository.ReservationSeatRepository;
@@ -24,20 +25,24 @@ public class ConfirmSeatSuccessPayloadHandler implements EventHandler<SeatConfir
     @Transactional
     public void handle(Event<SeatConfirmSuccessPayload> event) {
         SeatConfirmSuccessPayload payload = event.getPayload();
+        Long userId = payload.passportDto()
+                             .getUserId();
 
         List<ReservationSeat> seatIntanceList = reservationSeatRepository.findAllBySeatInstaceIdIn(payload.seatInstanceIdList());
         log.info("Received UUID List: {}",
                  payload.seatInstanceIdList());
+        Reservation reservation = seatIntanceList.get(0)
+                                                 .getReservation();
 
+        reservation.updateStatusConfirm(userId);
         log.info("조회된 seatInstanceList 개수: {}",
                  seatIntanceList.size());
         seatIntanceList.forEach(seat -> {
             log.info("수정 전 상태: {}",
                      seat.getStatus());
-            seat.updateStatusConfirmSuccess();
+            seat.updateStatusConfirm(userId);
             log.info("수정 후 상태: {}",
                      seat.getStatus());
-            seatIntanceList.forEach(ReservationSeat::updateStatusConfirmSuccess);
         });
 
 

--- a/reservation/src/main/java/com/earlybird/ticket/reservation/application/handler/PreemptSeatFailPayloadHandler.java
+++ b/reservation/src/main/java/com/earlybird/ticket/reservation/application/handler/PreemptSeatFailPayloadHandler.java
@@ -1,9 +1,9 @@
 package com.earlybird.ticket.reservation.application.handler;
 
-import com.earlybird.ticket.common.entity.PassportDto;
 import com.earlybird.ticket.reservation.application.dto.response.SeatPreemptFailPayload;
 import com.earlybird.ticket.reservation.application.event.EventHandler;
 import com.earlybird.ticket.reservation.domain.entity.Event;
+import com.earlybird.ticket.reservation.domain.entity.Reservation;
 import com.earlybird.ticket.reservation.domain.entity.ReservationSeat;
 import com.earlybird.ticket.reservation.domain.entity.constant.EventType;
 import com.earlybird.ticket.reservation.domain.repository.ReservationSeatRepository;
@@ -27,14 +27,14 @@ public class PreemptSeatFailPayloadHandler implements EventHandler<SeatPreemptFa
 
 
         List<ReservationSeat> seatIntanceList = reservationSeatRepository.findAllBySeatInstaceIdIn(payload.seatInstanceIdList());
-        PassportDto passport = payload.passportDto();
+        Long userId = payload.passportDto()
+                             .getUserId();
         seatIntanceList.forEach(reservationSeat -> {
-            reservationSeat.getReservation()
-                           .delete(passport.getUserId());
+            Reservation reservation = reservationSeat.getReservation();
+            reservation.updateStatusCancelled(userId);
 
             //예약 좌석 상태 FREE로 수정
-            reservationSeat.updateStatusReserveFREE();
-            reservationSeat.delete(passport.getUserId());
+            reservationSeat.updateStatusFREE(userId);
 
             //TODO:: 실패 알람 처리
             //Code를 가지고 내용 보내기

--- a/reservation/src/main/java/com/earlybird/ticket/reservation/application/handler/ReturnSeatFailPayloadHandler.java
+++ b/reservation/src/main/java/com/earlybird/ticket/reservation/application/handler/ReturnSeatFailPayloadHandler.java
@@ -4,6 +4,7 @@ import com.earlybird.ticket.common.entity.PassportDto;
 import com.earlybird.ticket.reservation.application.dto.response.SeatReturnFailPayload;
 import com.earlybird.ticket.reservation.application.event.EventHandler;
 import com.earlybird.ticket.reservation.domain.entity.Event;
+import com.earlybird.ticket.reservation.domain.entity.Reservation;
 import com.earlybird.ticket.reservation.domain.entity.ReservationSeat;
 import com.earlybird.ticket.reservation.domain.entity.constant.EventType;
 import com.earlybird.ticket.reservation.domain.repository.ReservationSeatRepository;
@@ -29,12 +30,11 @@ public class ReturnSeatFailPayloadHandler implements EventHandler<SeatReturnFail
         List<ReservationSeat> seatIntanceList = reservationSeatRepository.findAllBySeatInstaceIdIn(payload.seatInstanceIdList());
         PassportDto passport = payload.passportDto();
         seatIntanceList.forEach(reservationSeat -> {
-            reservationSeat.getReservation()
-                           .delete(passport.getUserId());
+            Reservation reservation = reservationSeat.getReservation();
+            reservation.delete(passport.getUserId());
 
             //예약 좌석 상태 FREE로 수정
-            reservationSeat.updateStatusReserveFREE();
-            reservationSeat.delete(passport.getUserId());
+            reservationSeat.updateStatusFREE(passport.getUserId());
 
             //TODO:: 실패 알람(메일) 처리
             //Code를 가지고 내용 보내기
@@ -42,7 +42,6 @@ public class ReturnSeatFailPayloadHandler implements EventHandler<SeatReturnFail
     }
 
     @Override
-
     public boolean support(Event<SeatReturnFailPayload> event) {
         return event.getEventType() == EventType.SEAT_RETURN_FAIL;
     }

--- a/reservation/src/main/java/com/earlybird/ticket/reservation/application/handler/ReturnSeatSuccessPayloadHandler.java
+++ b/reservation/src/main/java/com/earlybird/ticket/reservation/application/handler/ReturnSeatSuccessPayloadHandler.java
@@ -40,9 +40,9 @@ public class ReturnSeatSuccessPayloadHandler implements EventHandler<SeatReturnS
                      seat.getStatus());
         });
 
-        seatIntanceList.forEach(reservationSeat -> reservationSeat.updateStatusFREE(userId));
-        seatIntanceList.forEach(seat -> {
-            Reservation reservation = seat.getReservation();
+        seatIntanceList.forEach(reservationSeat -> {
+            reservationSeat.updateStatusFREE(userId);
+            Reservation reservation = reservationSeat.getReservation();
             reservation.updateStatusCancelled(userId);
         });
 

--- a/reservation/src/main/java/com/earlybird/ticket/reservation/application/service/ReservationServiceImpl.java
+++ b/reservation/src/main/java/com/earlybird/ticket/reservation/application/service/ReservationServiceImpl.java
@@ -5,6 +5,7 @@ import com.earlybird.ticket.common.util.PassportUtil;
 import com.earlybird.ticket.reservation.application.dto.CreateReservationCommand;
 import com.earlybird.ticket.reservation.application.dto.response.FindReservationQuery;
 import com.earlybird.ticket.reservation.common.exception.CustomJsonProcessingException;
+import com.earlybird.ticket.reservation.common.exception.LockFailedException;
 import com.earlybird.ticket.reservation.common.exception.NotFoundReservationException;
 import com.earlybird.ticket.reservation.common.exception.SeatAlreadyReservedException;
 import com.earlybird.ticket.reservation.common.util.EventPayloadConverter;
@@ -56,24 +57,24 @@ public class ReservationServiceImpl implements ReservationService {
     private final RedissonClient redissonClient;
 
 
-    //TODO::         validateReservationCommandsSeatInstanceId(createReservationCommands)을 삭제하고 Redis캐싱을 통해 이미 선점된 좌석인지 체크하고 락 획득
+    //TODO::validateReservationCommandsSeatInstanceId(createReservationCommands)을 삭제하고 Redis캐싱을 통해 이미 선점된 좌석인지 체크하고 락 획득
     @Override
     @Transactional
     public String createReservation(CreateReservationCommand createReservationCommands,
-        String passport) {
+                                    String passport) {
 
         PassportDto passportDto = passportUtil.getPassportDto(passport);
         Long userId = passportDto.getUserId();
 
         List<UUID> instanceSeatList = createReservationCommands.seatList()
-            .stream()
-            .map(SeatRequest::seatInstanceId)
-            .toList();
+                                                               .stream()
+                                                               .map(SeatRequest::seatInstanceId)
+                                                               .toList();
 
         // MultiRock 생성
         List<RLock> seatLocks = instanceSeatList.stream()
-            .map(id -> redissonClient.getLock("lock:seatInstance:" + id))
-            .toList();
+                                                .map(id -> redissonClient.getLock("lock:seatInstance:" + id))
+                                                .toList();
 
         RedissonMultiLock multiLock = new RedissonMultiLock(seatLocks.toArray(new RLock[0]));
 
@@ -83,39 +84,43 @@ public class ReservationServiceImpl implements ReservationService {
         for (int attempt = 1; attempt <= maxAttempts; attempt++) {
             try {
                 locked = multiLock.tryLock(3,
-                    10,
-                    TimeUnit.SECONDS);
+                                           10,
+                                           TimeUnit.SECONDS);
                 if (locked) {
                     break;
                 }
 
                 log.warn("[Retry:{}] 좌석 락 획득 실패. 재시도 예정",
-                    attempt);
+                         attempt);
                 long sleepMillis = (long) (Math.pow(2,
-                    attempt) * 100L + random.nextInt(150));
+                                                    attempt) * 100L + random.nextInt(150));
                 Thread.sleep(sleepMillis);
             } catch (InterruptedException e) {
                 Thread.currentThread()
-                    .interrupt();
+                      .interrupt();
                 throw new InternalServerErrorException("락 재시도 중 인터럽트 발생");
             }
         }
         if (!locked) {
-            log.error("[DLT] 좌석 락 시도 3회 초과");
-            throw new SeatAlreadyReservedException();
+            log.error("좌석 락 시도 3회 초과");
+            throw new LockFailedException();
         }
         validateReservationCommandsSeatInstanceId(createReservationCommands);
 
         try {
             // 2. 예약 생성
             Reservation reservation = createReservation(createReservationCommands,
-                userId);
+                                                        userId);
             reservation = reservationRepository.save(reservation);
 
             // 3. 예약 좌석 생성(기본적으로 예약된상태)
-            List<ReservationSeat> reservationSeatList = createReservationSeat(
-                createReservationCommands,
-                reservation);
+            List<ReservationSeat> reservationSeatList = createReservationSeat(createReservationCommands,
+                                                                              reservation);
+            if (createReservationCommands.seatList() == null || createReservationCommands.seatList()
+                                                                                         .isEmpty()) {
+                throw new IllegalArgumentException("seatList is empty or null");
+            }
+
             reservationSeatRepository.saveAll(reservationSeatList);
 
             // 4. 아웃박스 payload 생성 (seatInstanceIds를 한 번에)
@@ -124,13 +129,17 @@ public class ReservationServiceImpl implements ReservationService {
             }
 
             PreemptSeatEvent payload = PreemptSeatEvent.createSeatPreemptPayload(instanceSeatList,
-                passportDto,
-                reservation.getId());
+                                                                                 passportDto,
+                                                                                 reservation.getId());
 
             Event<PreemptSeatEvent> event = new Event<>(EventType.SEAT_PREEMPT,
-                payload,
-                LocalDateTime.now()
-                    .toString());
+                                                        payload,
+                                                        LocalDateTime.now()
+                                                                     .toString());
+
+            if (event == null) {
+                throw new IllegalStateException("event is null before serialization");
+            }
 
             String payloadJson;
             payloadJson = new ObjectMapper().writeValueAsString(event);
@@ -138,22 +147,22 @@ public class ReservationServiceImpl implements ReservationService {
             // 5. Outbox 저장
             // 동기 처리시에는 Outbox패턴이 아닌 커밋이전에 데이터를 발행하고 응답을 받아오는 방식으로 수행해야 함
             Outbox outbox = Outbox.builder()
-                .aggregateType(Outbox.AggregateType.RESERVATION)
-                .aggregateId(reservation.getId())
-                .eventType(EventType.SEAT_PREEMPT)
-                .payload(payloadJson)
-                .build();
+                                  .aggregateType(Outbox.AggregateType.RESERVATION)
+                                  .aggregateId(reservation.getId())
+                                  .eventType(EventType.SEAT_PREEMPT)
+                                  .payload(payloadJson)
+                                  .build();
 
             outboxRepository.save(outbox);
 
             //6. 예약 ID값 반환
             return reservation.getId()
-                .toString();
+                              .toString();
         } catch (JsonProcessingException e) {
             throw new CustomJsonProcessingException();
         } catch (Exception e) {
             sendToDLT(instanceSeatList,
-                passportDto);
+                      passportDto);
         } finally {
             if (locked) {
                 multiLock.unlock();
@@ -163,21 +172,20 @@ public class ReservationServiceImpl implements ReservationService {
     }
 
     private void sendToDLT(List<UUID> instanceSeatList,
-        PassportDto passportDto) {
-        Event<PreemptSeatDltEvent> preemptSeatDltEventEvent = new Event<>(
-            EventType.RESERVATION_LOCK_FAIL,
-            PreemptSeatDltEvent.createSeatPreemptPayload(instanceSeatList,
-                passportDto),
-            LocalDateTime.now()
-                .toString());
+                           PassportDto passportDto) {
+        Event<PreemptSeatDltEvent> preemptSeatDltEventEvent = new Event<>(EventType.RESERVATION_LOCK_FAIL,
+                                                                          PreemptSeatDltEvent.createSeatPreemptPayload(instanceSeatList,
+                                                                                                                       passportDto),
+                                                                          LocalDateTime.now()
+                                                                                       .toString());
         String payload = eventPayloadConverter.serializePayload(preemptSeatDltEventEvent);
 
         Outbox dltOutbox = Outbox.builder()
-            .aggregateId(instanceSeatList.get(0))
-            .aggregateType("DLT")
-            .eventType(EventType.RESERVATION_LOCK_FAIL)
-            .payload(payload)
-            .build();
+                                 .aggregateId(instanceSeatList.get(0))
+                                 .aggregateType("DLT")
+                                 .eventType(EventType.RESERVATION_LOCK_FAIL)
+                                 .payload(payload)
+                                 .build();
 
         outboxRepository.save(dltOutbox);
 
@@ -186,16 +194,15 @@ public class ReservationServiceImpl implements ReservationService {
     @Override
     @Transactional
     public void cancelReservation(UUID reservationId,
-        String passport) {
+                                  String passport) {
 
         PassportDto passportDto = passportUtil.getPassportDto(passport);
         //1. 예약 엔티티 조회
         Reservation reservation = reservationRepository.findById(reservationId)
-            .orElseThrow(NotFoundReservationException::new);
+                                                       .orElseThrow(NotFoundReservationException::new);
 
         //2. 반환 좌석 조회
-        List<ReservationSeat> reservationSeatList = reservationSeatRepository.findByReservation(
-            reservation);
+        List<ReservationSeat> reservationSeatList = reservationSeatRepository.findByReservation(reservation);
         //2. 예약 취소
         UUID paymentId = reservation.getPaymentId();
 
@@ -204,43 +211,42 @@ public class ReservationServiceImpl implements ReservationService {
         //고도화에서 진행할 예정
 
         Event<ReturnCouponEvent> returnCouponEvent = new Event<>(EventType.COUPON_RETURN,
-            ReturnCouponEvent.builder()
-                .passportDto(passportDto)
-                .code("C01")
-                .couponId(reservation.getCouponId())
-                .build(),
-            LocalDateTime.now()
-                .toString());
+                                                                 ReturnCouponEvent.builder()
+                                                                                  .passportDto(passportDto)
+                                                                                  .code("C01")
+                                                                                  .couponId(reservation.getCouponId())
+                                                                                  .build(),
+                                                                 LocalDateTime.now()
+                                                                              .toString());
 
         String couponRecord = eventPayloadConverter.serializePayload(returnCouponEvent);
 
         Outbox couponOutbox = Outbox.builder()
-            .aggregateId(reservation.getId())
-            .aggregateType("RESERVATION")
-            .eventType(EventType.COUPON_RETURN)
-            .payload(couponRecord)
-            .build();
+                                    .aggregateId(reservation.getId())
+                                    .aggregateType("RESERVATION")
+                                    .eventType(EventType.COUPON_RETURN)
+                                    .payload(couponRecord)
+                                    .build();
 
         outboxRepository.save(couponOutbox);
 
         Event<ReturnSeatEvent> returnSeatPayloadEvent = new Event<>(EventType.SEAT_RETURN,
-            ReturnSeatEvent.builder()
-                .seatInstanceIdList(reservationSeatList.stream()
-                    .map(ReservationSeat::getId)
-                    .toList())
-                .passportDto(passportDto)
-                .build(),
-            LocalDateTime.now()
-                .toString());
-        //TODO :: serialize한 변수들 이름 일치시키기
+                                                                    ReturnSeatEvent.builder()
+                                                                                   .seatInstanceIdList(reservationSeatList.stream()
+                                                                                                                          .map(ReservationSeat::getId)
+                                                                                                                          .toList())
+                                                                                   .passportDto(passportDto)
+                                                                                   .build(),
+                                                                    LocalDateTime.now()
+                                                                                 .toString());
         String payloadRecord = eventPayloadConverter.serializePayload(returnSeatPayloadEvent);
 
         Outbox seatOutbox = Outbox.builder()
-            .aggregateId(reservation.getId())
-            .aggregateType("RESERVATION")
-            .eventType(EventType.SEAT_RETURN)
-            .payload(payloadRecord)
-            .build();
+                                  .aggregateId(reservation.getId())
+                                  .aggregateType("RESERVATION")
+                                  .eventType(EventType.SEAT_RETURN)
+                                  .payload(payloadRecord)
+                                  .build();
 
         outboxRepository.save(seatOutbox);
 
@@ -252,86 +258,82 @@ public class ReservationServiceImpl implements ReservationService {
     @Override
     @Transactional(readOnly = true)
     public FindReservationQuery findReservation(UUID reservationId,
-        String passport) {
+                                                String passport) {
 
         Reservation reservation = reservationRepository.findById(reservationId)
-            .orElseThrow(NotFoundReservationException::new);
+                                                       .orElseThrow(NotFoundReservationException::new);
 
-        List<ReservationSeat> reservationSeatList = reservationSeatRepository.findByReservation(
-            reservation);
+        List<ReservationSeat> reservationSeatList = reservationSeatRepository.findByReservation(reservation);
 
         return FindReservationQuery.createFindReservationQuery(reservation,
-            reservationSeatList);
+                                                               reservationSeatList);
     }
 
     @Override
     public Page<ReservationSearchResult> searchReservations(Pageable pageable,
-        String q,
-        String startTime,
-        String endTime,
-        String passport) {
+                                                            String q,
+                                                            String startTime,
+                                                            String endTime,
+                                                            String passport) {
 
         PassportDto passportDto = passportUtil.getPassportDto(passport);
         return reservationSeatRepository.searchReservations(q,
-            startTime,
-            endTime,
-            pageable,
-            passportDto);
+                                                            startTime,
+                                                            endTime,
+                                                            pageable,
+                                                            passportDto);
 
     }
 
     private Reservation createReservation(CreateReservationCommand createReservationCommand,
-        Long userId) {
+                                          Long userId) {
         return Reservation.createReservation(userId,
-            createReservationCommand.userName(),
-            createReservationCommand.concertId(),
-            createReservationCommand.concertName(),
-            createReservationCommand.concertSequenceId(),
-            createReservationCommand.concertSequenceStartDatetime(),
-            createReservationCommand.concertSequenceEndDatetime(),
-            createReservationCommand.concertSequenceStatus(),
-            createReservationCommand.venueId(),
-            createReservationCommand.venueArea(),
-            createReservationCommand.venueLocation(),
-            createReservationCommand.content(),
-            createReservationCommand.couponId(),
-            createReservationCommand.couponType(),
-            createReservationCommand.couponName(),
-            createReservationCommand.couponStatus(),
-            createReservationCommand.hallId(),
-            createReservationCommand.hallName(),
-            createReservationCommand.hallFloor());
+                                             createReservationCommand.userName(),
+                                             createReservationCommand.concertId(),
+                                             createReservationCommand.concertName(),
+                                             createReservationCommand.concertSequenceId(),
+                                             createReservationCommand.concertSequenceStartDatetime(),
+                                             createReservationCommand.concertSequenceEndDatetime(),
+                                             createReservationCommand.concertSequenceStatus(),
+                                             createReservationCommand.venueId(),
+                                             createReservationCommand.venueArea(),
+                                             createReservationCommand.venueLocation(),
+                                             createReservationCommand.content(),
+                                             createReservationCommand.couponId(),
+                                             createReservationCommand.couponType(),
+                                             createReservationCommand.couponName(),
+                                             createReservationCommand.couponStatus(),
+                                             createReservationCommand.hallId(),
+                                             createReservationCommand.hallName(),
+                                             createReservationCommand.hallFloor());
     }
 
-    private List<ReservationSeat> createReservationSeat(
-        CreateReservationCommand createReservationCommand,
-        Reservation reservation) {
+    private List<ReservationSeat> createReservationSeat(CreateReservationCommand createReservationCommand,
+                                                        Reservation reservation) {
         return createReservationCommand.seatList()
-            .stream()
-            .map(seatCommand -> ReservationSeat.createReservationSeat(reservation,
-                seatCommand.seatInstanceId(),
-                createReservationCommand.concertId(),
-                seatCommand.seatRow(),
-                seatCommand.seatCol(),
-                seatCommand.seatGrade(),
-                seatCommand.seatPrice()))
-            .toList();
+                                       .stream()
+                                       .map(seatCommand -> ReservationSeat.createReservationSeat(reservation,
+                                                                                                 seatCommand.seatInstanceId(),
+                                                                                                 createReservationCommand.concertId(),
+                                                                                                 seatCommand.seatRow(),
+                                                                                                 seatCommand.seatCol(),
+                                                                                                 seatCommand.seatGrade(),
+                                                                                                 seatCommand.seatPrice()))
+                                       .toList();
     }
 
-    private void validateReservationCommandsSeatInstanceId(
-        CreateReservationCommand createReservationCommands) {
+    private void validateReservationCommandsSeatInstanceId(CreateReservationCommand createReservationCommands) {
         //해당 좌석이 FREE가 아닌 상태가 있다면
         createReservationCommands.seatList()
-            .forEach(seatRequest -> {
-                boolean isSeatReservationExist = reservationSeatRepository.existsBySeatInstanceIdAndSeatStatusNotFREE(
-                    seatRequest.seatInstanceId(),
-                    SeatStatus.FREE);
+                                 .forEach(seatRequest -> {
+                                     boolean isSeatReservationExist = reservationSeatRepository.existsBySeatInstanceIdAndSeatStatusNotFREE(seatRequest.seatInstanceId(),
+                                                                                                                                           SeatStatus.FREE);
 
-                //예외 발생
-                if (isSeatReservationExist) {
-                    throw new SeatAlreadyReservedException();
-                }
-            });
+                                     //예외 발생
+                                     if (isSeatReservationExist) {
+                                         throw new SeatAlreadyReservedException();
+                                     }
+                                 });
 
     }
 }

--- a/reservation/src/main/java/com/earlybird/ticket/reservation/common/exception/LockFailedException.java
+++ b/reservation/src/main/java/com/earlybird/ticket/reservation/common/exception/LockFailedException.java
@@ -1,0 +1,11 @@
+package com.earlybird.ticket.reservation.common.exception;
+
+import com.earlybird.ticket.common.entity.constant.Code;
+import com.earlybird.ticket.common.exception.AbstractException;
+
+public class LockFailedException extends AbstractException {
+    public LockFailedException() {
+        super("Failed To Earn Lcok",
+              Code.BAD_REQUEST);
+    }
+}

--- a/reservation/src/main/java/com/earlybird/ticket/reservation/domain/entity/Reservation.java
+++ b/reservation/src/main/java/com/earlybird/ticket/reservation/domain/entity/Reservation.java
@@ -199,16 +199,6 @@ public class Reservation extends BaseEntity {
                           .build();
     }
 
-
-    public void cancelReservation(Long userId) {
-        this.delete(userId);
-    }
-
-    public void updateStatusPending(Long userId) {
-        this.delete(userId);
-        this.reservationStatus = ReservationStatus.CANCELLED;
-    }
-
     public void updateCouponData(CouponReservePayload payload) {
         validateCouponData(payload);
         this.couponId = payload.couponId();
@@ -228,8 +218,22 @@ public class Reservation extends BaseEntity {
         this.paymentId = payload.paymentId();
         this.paymentTotalPrice = payload.totalPrice();
         this.paymentStatus = payload.paymentStatus();
-        this.reservationStatus = ReservationStatus.CONFIRMED;
         update(payload.passportDto()
                       .getUserId());
+    }
+
+    public void updateStatusConfirm(Long userId) {
+        this.reservationStatus = ReservationStatus.CONFIRMED;
+        update(userId);
+    }
+
+    public void updateStatusPaying(Long userId) {
+        this.reservationStatus = ReservationStatus.PAYING;
+        update(userId);
+    }
+
+    public void updateStatusCancelled(Long userId) {
+        this.reservationStatus = ReservationStatus.CANCELLED;
+        this.delete(userId);
     }
 }

--- a/reservation/src/main/java/com/earlybird/ticket/reservation/domain/entity/ReservationSeat.java
+++ b/reservation/src/main/java/com/earlybird/ticket/reservation/domain/entity/ReservationSeat.java
@@ -92,15 +92,18 @@ public class ReservationSeat extends BaseEntity {
                               .build();
     }
 
-    public void updateStatusReserveSuccess() {
-        this.status = SeatStatus.PREEMPTED;
-    }
-
-    public void updateStatusReserveFREE() {
+    public void updateStatusFREE(Long userId) {
         this.status = SeatStatus.FREE;
+        delete(userId);
     }
 
-    public void updateStatusConfirmSuccess() {
+    public void updateStatusPreempted(Long userId) {
+        this.status = SeatStatus.PREEMPTED;
+        update(userId);
+    }
+
+    public void updateStatusConfirm(Long userId) {
         this.status = SeatStatus.CONFIRMED;
+        update(userId);
     }
 }

--- a/reservation/src/main/java/com/earlybird/ticket/reservation/infrastructure/messaging/producer/ReservationKafkaOutboxProducer.java
+++ b/reservation/src/main/java/com/earlybird/ticket/reservation/infrastructure/messaging/producer/ReservationKafkaOutboxProducer.java
@@ -23,7 +23,7 @@ public class ReservationKafkaOutboxProducer {
     private final OutboxRepository outboxRepository;
     private final KafkaTemplate<String, String> kafkaTemplate;
 
-    @Scheduled(fixedDelay = 3000)
+    @Scheduled(fixedDelay = 7000)
     @Transactional
     public void publishPendingOutboxMessages() {
         List<Outbox> pendingOutboxes = outboxRepository.findTOP100ByOrderByCreatedAtAsc();

--- a/reservation/src/main/resources/application.yml
+++ b/reservation/src/main/resources/application.yml
@@ -26,7 +26,7 @@ spring:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
       ddl-auto: update
-    show-sql: true
+    #    show-sql: true
     open-in-view: false
 
 server:


### PR DESCRIPTION
…at 상태 변경 수정

## 변경 타입

- [ ] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 테스트 항목

- [ ] 코드가 의도한 대로 동작하는지 테스트 완료
- [ ] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음

## 변경 내용

- **as-is**
    - (변경 전 설명을 여기에 작성)

- **to-be**
 - [ ]  좌석 선점,확정 실패시 - Reservation -> CANCELLED 및 삭제 처리, ReservationSeat -> FREE 및 삭제 처리
- [ ]  좌석 확정 성공시 - Reservation, ReservationSeat -> CONFIRM 처리
- [ ]  좌석 선점 성공시 - Reservation -> PAYING ,  ReservationSeat -> PREEMPTED
- [ ] 결제 성공 시 -> 기존에는 좌석 상태는 CONFIRMED로 수정했으나 이제 수정하지 않음, CONFIRM 성공 메세지가 왔을때만 수정
- [ ] 좌석 반환 실패 시 - 고민중
- [ ] 좌석 반환 성공 시 - Reservation-> CANCELLED , Reservation Seat -> FREE 및 삭제처리

## 참조

[ET-160](https://challduck.atlassian.net/jira/software/projects/ET/boards/36?selectedIssue=ET-160)

## 코멘트

- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 락 획득 실패 시 사용할 새로운 예외(LockFailedException)가 추가되었습니다.

- **버그 수정**
    - 좌석 및 예약 상태 변경 시 사용자 ID를 명시적으로 전달하여 처리 일관성이 향상되었습니다.
    - 좌석 반환, 예약 확정, 선점 실패 등 다양한 상황에서 상태 업데이트 로직이 개선되었습니다.

- **성능 및 안정성 개선**
    - 분산 락 획득 재시도 후 실패 시 더 명확한 예외 처리 및 데드레터 전송 로직이 강화되었습니다.
    - 예약 생성 시 입력값에 대한 방어적 검증이 추가되었습니다.

- **운영 및 설정**
    - 예약 관련 카프카 아웃박스 메시지 발송 주기가 3초에서 7초로 조정되었습니다.
    - SQL 로그 출력이 기본적으로 비활성화되었습니다.

- **코드 리팩터링**
    - 예약 및 좌석 엔티티의 상태 변경 메서드가 명확하게 분리되고, 불필요한 메서드는 제거되었습니다.
    - 불필요한 로그 및 주석이 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->