### PR TITLE
[ET-108] 결제 취소 이벤트 방식으로 변경

### DIFF
--- a/payment/src/main/java/com/earlybird/ticket/payment/application/event/dispatcher/EventDispatcher.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/application/event/dispatcher/EventDispatcher.java
@@ -1,0 +1,9 @@
+package com.earlybird.ticket.payment.application.event.dispatcher;
+
+import com.earlybird.ticket.common.entity.EventPayload;
+import com.earlybird.ticket.payment.domain.entity.Event;
+
+public interface EventDispatcher {
+
+    void handle(Event<? extends EventPayload> event);
+}

--- a/payment/src/main/java/com/earlybird/ticket/payment/application/event/dispatcher/EventDispatcherImpl.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/application/event/dispatcher/EventDispatcherImpl.java
@@ -1,0 +1,29 @@
+package com.earlybird.ticket.payment.application.event.dispatcher;
+
+import com.earlybird.ticket.common.entity.EventPayload;
+import com.earlybird.ticket.payment.application.event.handler.EventHandler;
+import com.earlybird.ticket.payment.domain.entity.Event;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EventDispatcherImpl implements EventDispatcher {
+
+    private final List<EventHandler<? extends EventPayload>> handlers;
+
+
+    @Override
+    public void handle(Event<? extends EventPayload> event) {
+        handlers.stream()
+            .filter(handler -> ((EventHandler) handler).supports(event))
+            .findFirst()
+            .ifPresentOrElse(
+                handler -> ((EventHandler) handler).handle(event),
+                () -> log.error("No handler found for event: {}", event.getEventType())
+            );
+    }
+}

--- a/payment/src/main/java/com/earlybird/ticket/payment/application/event/dto/response/ReservationCancelPayload.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/application/event/dto/response/ReservationCancelPayload.java
@@ -1,0 +1,13 @@
+package com.earlybird.ticket.payment.application.event.dto.response;
+
+import com.earlybird.ticket.common.entity.EventPayload;
+import com.earlybird.ticket.common.entity.PassportDto;
+import java.util.UUID;
+
+public record ReservationCancelPayload(
+    PassportDto passportDto,
+    UUID reservationId,
+    UUID paymentId
+) implements EventPayload {
+
+}

--- a/payment/src/main/java/com/earlybird/ticket/payment/application/event/handler/EventHandler.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/application/event/handler/EventHandler.java
@@ -1,0 +1,11 @@
+package com.earlybird.ticket.payment.application.event.handler;
+
+import com.earlybird.ticket.common.entity.EventPayload;
+import com.earlybird.ticket.payment.domain.entity.Event;
+
+public interface EventHandler<T extends EventPayload> {
+
+    void handle(Event<T> event);
+
+    boolean supports(Event<T> event);
+}

--- a/payment/src/main/java/com/earlybird/ticket/payment/application/event/handler/ReservationCancelPayloadHandler.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/application/event/handler/ReservationCancelPayloadHandler.java
@@ -1,0 +1,33 @@
+package com.earlybird.ticket.payment.application.event.handler;
+
+import com.earlybird.ticket.common.entity.PassportDto;
+import com.earlybird.ticket.payment.application.event.dto.response.ReservationCancelPayload;
+import com.earlybird.ticket.payment.application.service.PaymentService;
+import com.earlybird.ticket.payment.common.EventType;
+import com.earlybird.ticket.payment.domain.entity.Event;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationCancelPayloadHandler implements EventHandler<ReservationCancelPayload> {
+
+    private final PaymentService paymentService;
+
+    @Override
+    public void handle(Event<ReservationCancelPayload> event) {
+        ReservationCancelPayload payload = event.getPayload();
+        log.info("예약 취소 이벤트 수신 -> {}", payload);
+
+        PassportDto passportDto = payload.passportDto();
+
+        paymentService.cancelPayment(payload.paymentId(), passportDto);
+    }
+
+    @Override
+    public boolean supports(Event<ReservationCancelPayload> event) {
+        return event.getEventType() == EventType.RESERVATION_CANCEL;
+    }
+}

--- a/payment/src/main/java/com/earlybird/ticket/payment/application/service/PaymentService.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/application/service/PaymentService.java
@@ -1,16 +1,18 @@
 package com.earlybird.ticket.payment.application.service;
 
+import com.earlybird.ticket.common.entity.PassportDto;
 import com.earlybird.ticket.payment.application.service.dto.command.ConfirmPaymentCommand;
 import com.earlybird.ticket.payment.application.service.dto.command.CreatePaymentCommand;
 import com.earlybird.ticket.payment.application.service.dto.query.FindPaymentQuery;
 import java.util.UUID;
 
 public interface PaymentService {
+
     UUID createPayment(CreatePaymentCommand paymentRequest);
 
     FindPaymentQuery findPayment(UUID paymentId);
 
     void confirmPayment(ConfirmPaymentCommand confirmPaymentCommand);
 
-    void cancelPayment(UUID paymentId);
+    void cancelPayment(UUID paymentId, PassportDto passportDto);
 }

--- a/payment/src/main/java/com/earlybird/ticket/payment/application/service/TestPaymentServiceImpl.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/application/service/TestPaymentServiceImpl.java
@@ -121,7 +121,7 @@ public class TestPaymentServiceImpl implements PaymentService {
 
     @Override
     @Transactional
-    public void cancelPayment(UUID paymentId) {
+    public void cancelPayment(UUID paymentId, PassportDto passportDto) {
         Payment payment = paymentRepository.findByPaymentId(paymentId)
             .orElseThrow(PaymentNotFoundException::new);
 

--- a/payment/src/main/java/com/earlybird/ticket/payment/application/service/dto/command/UpdatePaymentCommand.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/application/service/dto/command/UpdatePaymentCommand.java
@@ -3,13 +3,15 @@ package com.earlybird.ticket.payment.application.service.dto.command;
 import com.earlybird.ticket.payment.domain.entity.Payment;
 import com.earlybird.ticket.payment.domain.entity.constant.PaymentMethod;
 import com.earlybird.ticket.payment.domain.entity.constant.PaymentStatus;
+import java.time.LocalDateTime;
 import lombok.Builder;
 
 @Builder
 public record UpdatePaymentCommand(
     PaymentMethod paymentMethod,
     PaymentStatus status,
-    String paymentKey
+    String paymentKey,
+    LocalDateTime approvedAt
 ) {
 
     public Payment toPayment(Long userId) {

--- a/payment/src/main/java/com/earlybird/ticket/payment/application/service/exception/PaymentInformationDoesNotMatchException.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/application/service/exception/PaymentInformationDoesNotMatchException.java
@@ -1,0 +1,10 @@
+package com.earlybird.ticket.payment.application.service.exception;
+
+import com.earlybird.ticket.common.entity.constant.Code;
+
+public class PaymentInformationDoesNotMatchException extends AbstractPaymentException {
+
+    public PaymentInformationDoesNotMatchException() {
+        super("결제 정보가 일치하지 않습니다.", Code.BAD_REQUEST);
+    }
+}

--- a/payment/src/main/java/com/earlybird/ticket/payment/application/service/exception/PaymentNonRecoverableException.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/application/service/exception/PaymentNonRecoverableException.java
@@ -1,0 +1,10 @@
+package com.earlybird.ticket.payment.application.service.exception;
+
+import com.earlybird.ticket.common.entity.constant.Code;
+
+public class PaymentNonRecoverableException extends AbstractPaymentException {
+
+    public PaymentNonRecoverableException() {
+        super("결제 메시지 처리 실패", Code.RECOVERABLE);
+    }
+}

--- a/payment/src/main/java/com/earlybird/ticket/payment/common/EventType.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/common/EventType.java
@@ -3,6 +3,7 @@ package com.earlybird.ticket.payment.common;
 import com.earlybird.ticket.common.entity.EventPayload;
 import com.earlybird.ticket.payment.application.event.dto.request.PaymentSuccessEvent;
 import com.earlybird.ticket.payment.application.event.dto.request.PaymentFailEvent;
+import com.earlybird.ticket.payment.application.event.dto.response.ReservationCancelPayload;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,8 +14,10 @@ import lombok.extern.slf4j.Slf4j;
 public enum EventType {
     PAYMENT_SUCCESS(PaymentSuccessEvent.class, Topic.PAYMENT_TO_RESERVATION_TOPIC),
     PAYMENT_FAIL(PaymentFailEvent.class, Topic.PAYMENT_TO_RESERVATION_TOPIC),
+//    PAYMENT_CANCEL(PaymentSuccessEvent.class, Topic.PAYMENT_TO_PAYMENT_TOPIC),
+    RESERVATION_CANCEL(ReservationCancelPayload.class, Topic.RESERVATION_TO_PAYMENT_TOPIC)
     ;
-    
+
     private final Class<? extends EventPayload> payloadClass;
     private final String topic;
 
@@ -30,5 +33,8 @@ public enum EventType {
     public static class Topic {
 
         public static final String PAYMENT_TO_RESERVATION_TOPIC = "PaymentToReservation";
+        public static final String RESERVATION_TO_PAYMENT_TOPIC = "ReservationToPayment";
+//        public static final String PAYMENT_TO_PAYMENT_TOPIC = "PaymentToPayment";
+
     }
 }

--- a/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/client/PaymentWebClient.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/client/PaymentWebClient.java
@@ -74,6 +74,7 @@ public class PaymentWebClient implements PaymentClient {
                     });
             })
             .block();
+
         log.info("토스페이 결제 성공 = {}", receipt);
 
         return receipt.toCommand();

--- a/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/client/dto/response/ProcessPaymentConfirmClientResponse.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/client/dto/response/ProcessPaymentConfirmClientResponse.java
@@ -3,21 +3,52 @@ package com.earlybird.ticket.payment.infrastructure.client.dto.response;
 import com.earlybird.ticket.payment.application.service.dto.command.UpdatePaymentCommand;
 import com.earlybird.ticket.payment.domain.entity.constant.PaymentMethod;
 import com.earlybird.ticket.payment.domain.entity.constant.PaymentStatus;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import lombok.Builder;
 
 @Builder
 public record ProcessPaymentConfirmClientResponse(
     String method,
     String status,
-    String paymentKey
-//    OffsetDateTime approvedAt
+    String paymentKey,
+
+    @JsonProperty("approvedAt")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
+    OffsetDateTime approvedAt,
+    // 가상계좌에서 사용
+    @JsonProperty("requestedAt")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
+    OffsetDateTime requestedAt
 ) {
+
+    private static final String VIRTUAL_ACCOUNT = "가상계좌";
 
     public UpdatePaymentCommand toCommand() {
         return UpdatePaymentCommand.builder()
             .paymentMethod(PaymentMethod.from(method))
             .status(PaymentStatus.from(status))
             .paymentKey(paymentKey)
+            .approvedAt(transformDate())
             .build();
+    }
+
+    /* TODO : 결제 성공 시간과 요청시간 분리
+        가상계좌의 경우 요청 시간에서 일정 시간 지난 경우 취소처리
+       현재는 가상계좌의 경우 요청 시간으로 결제 성공 시간을 대신함
+    */
+    public LocalDateTime transformDate() {
+        if (method.equals(VIRTUAL_ACCOUNT)) {
+            return requestedAt.toInstant()
+                .atZone(ZoneId.systemDefault())
+                .toLocalDateTime();
+        }
+
+        return approvedAt.toInstant()
+            .atZone(ZoneId.systemDefault())
+            .toLocalDateTime();
     }
 }

--- a/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/config/KafkaConsumerConfig.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/config/KafkaConsumerConfig.java
@@ -1,0 +1,109 @@
+package com.earlybird.ticket.payment.infrastructure.config;
+
+
+import com.earlybird.ticket.payment.application.service.exception.PaymentNonRecoverableException;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.ExponentialBackOffWithMaxRetries;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+    Map<String, Object> props = new HashMap<>();
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @ConditionalOnMissingBean
+    public ConsumerFactory<String, String> consumerFactory() {
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers); // Kafka 브로커 리스트 설정
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+            StringDeserializer.class); // 메시지 키 역직렬화 방식 설정
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+            StringDeserializer.class); // 메시지 값 역직렬화 방식 설정
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*"); // 신뢰할 수 있는 패키지 설정 (역직렬화 시 필요한 설정)
+
+        // Consumer 그룹 ID 설정 (여러 Consumer가 같은 그룹에서 동일한 메시지를 처리하지 않도록 함)
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "test-group-id");
+
+        // Offset 자동 커밋 비활성화 (중복 방지, 수동 커밋 사용)
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+
+        // Kafka 컨슈머가 읽을 오프셋 위치 설정 (earliest: 가장 오래된 메시지부터 읽음, 기본값은 latest)
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+        // 한 번의 poll() 요청에서 가져올 최대 레코드 수 (성능 조절, 테스트하면서 수를 건드려야 할듯)
+        props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 20);
+
+        // Poll 간격 최대 시간 (이 시간을 초과하면 Consumer 그룹에서 제거됨)
+        props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, 15000);
+
+        // Heartbeat 주기 (Consumer가 정상적으로 살아있음을 브로커에 알림)
+        props.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 1000);
+
+        // Consumer가 장애로 인해 응답하지 않을 경우 제거되는 시간 (세션 타임아웃)
+        props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 60000);
+
+        return new DefaultKafkaConsumerFactory<>(
+            props,
+            new StringDeserializer(),
+            new StringDeserializer()
+        );
+    }
+
+    @Bean(name = "kafkaListenerContainerFactory")
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+        DefaultErrorHandler defaultErrorHandler) {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+
+        // 메시지 처리 완료 즉시 커밋 (중복 방지)
+        factory.getContainerProperties()
+            .setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
+        factory.setCommonErrorHandler(defaultErrorHandler);
+
+        return factory;
+    }
+
+    @Bean
+    public DefaultErrorHandler errorHandler(KafkaTemplate<String, String> kafkaTemplate) {
+        // DLQ 설정
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(kafkaTemplate,
+            (record, ex) -> {
+                // 원본 토픽 이름에 .DLT 접미사 추가
+                return new TopicPartition(record.topic() + ".DLT",
+                    record.partition());
+            });
+        // 지터를 포함한 지수 백오프 설정 (최대 5회)
+        ExponentialBackOffWithMaxRetries backoff = new ExponentialBackOffWithMaxRetries(3);
+        backoff.setInitialInterval(2000); // 2초
+        backoff.setMultiplier(2.0);       // 2배씩 증가
+        backoff.setMaxInterval(10000);    // 최대 10초
+
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, backoff);
+
+        // 특정 예외는 재시도하지 않고 바로 DLQ로 보내고 싶을 때
+        // 이 예외는 재시도 하지 않고 바로 DLQ로 보냄
+        errorHandler.addNotRetryableExceptions(
+            PaymentNonRecoverableException.class,
+            IllegalArgumentException.class
+        );
+
+        return errorHandler;
+    }
+}

--- a/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/messaging/consumer/PaymentKafkaEventListener.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/messaging/consumer/PaymentKafkaEventListener.java
@@ -1,8 +1,40 @@
 package com.earlybird.ticket.payment.infrastructure.messaging.consumer;
 
+import com.earlybird.ticket.payment.application.event.dispatcher.EventDispatcher;
+import com.earlybird.ticket.payment.application.service.exception.PaymentNonRecoverableException;
+import com.earlybird.ticket.payment.common.EventType.Topic;
+import com.earlybird.ticket.payment.domain.entity.Event;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
+@RequiredArgsConstructor
 public class PaymentKafkaEventListener {
 
+    private final EventDispatcher eventDispatcher;
+
+    @KafkaListener(
+        topics = {
+            Topic.RESERVATION_TO_PAYMENT_TOPIC,
+//            Topic.PAYMENT_TO_PAYMENT_TOPIC
+        },
+        containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void listen(@Payload String message, Acknowledgment ack) {
+        try {
+            log.info("message = {}", message);
+            // TODO : EventDispatcher 구현
+            eventDispatcher.handle(Event.fromJson(message));
+            ack.acknowledge();
+
+        } catch (Exception e) {
+            log.error("메시지 처리 실패: {}", e.getMessage());
+            throw new PaymentNonRecoverableException();
+        }
+    }
 }

--- a/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/messaging/consumer/PaymentKafkaEventListener.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/messaging/consumer/PaymentKafkaEventListener.java
@@ -1,4 +1,4 @@
-package com.earlybird.ticket.payment.infrastructure.messaging;
+package com.earlybird.ticket.payment.infrastructure.messaging.consumer;
 
 import org.springframework.stereotype.Component;
 

--- a/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/messaging/producer/KafkaProducerInterceptor.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/messaging/producer/KafkaProducerInterceptor.java
@@ -1,4 +1,4 @@
-package com.earlybird.ticket.payment.infrastructure.config;
+package com.earlybird.ticket.payment.infrastructure.messaging.producer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.HashMap;

--- a/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/messaging/producer/KafkaProducerListener.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/messaging/producer/KafkaProducerListener.java
@@ -1,4 +1,4 @@
-package com.earlybird.ticket.payment.infrastructure.config;
+package com.earlybird.ticket.payment.infrastructure.messaging.producer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.HashMap;

--- a/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/messaging/producer/PaymentKafkaOutboxProducer.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/messaging/producer/PaymentKafkaOutboxProducer.java
@@ -1,4 +1,4 @@
-package com.earlybird.ticket.payment.infrastructure.messaging;
+package com.earlybird.ticket.payment.infrastructure.messaging.producer;
 
 import com.earlybird.ticket.payment.domain.entity.Outbox;
 import com.earlybird.ticket.payment.domain.repository.OutboxRepository;
@@ -29,10 +29,7 @@ public class PaymentKafkaOutboxProducer {
         List<CompletableFuture<Outbox>> futures = outboxes.stream()
             .map(outbox -> {
                 log.info("Outbox 발행] id = {}, payload = {}", outbox.getId(), outbox.getPayload());
-                // 실패 테스트
-//                CompletableFuture<Object> failed = new CompletableFuture<>();
-//                failed.completeExceptionally(new RuntimeException("테스트"));
-//                return failed
+
                 return paymentKafkaTemplate.send(
                         outbox.getEventType().getTopic(),
                         outbox.getPayload()

--- a/payment/src/main/java/com/earlybird/ticket/payment/presentation/PaymentExternalController.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/presentation/PaymentExternalController.java
@@ -54,13 +54,4 @@ public class PaymentExternalController {
 
         return ResponseEntity.ok(CommonDto.ok(null, "결제 확정 성공"));
     }
-
-    // event로 변경 예정
-    @DeleteMapping("/{paymentId}")
-    public ResponseEntity<CommonDto<Void>> cancelPayment(
-        @PathVariable(name = "paymentId") UUID paymentId
-    ) {
-        paymentService.cancelPayment(paymentId);
-        return ResponseEntity.ok(CommonDto.ok(null, "결제 취소 성공"));
-    }
 }

--- a/payment/src/main/resources/application.yml
+++ b/payment/src/main/resources/application.yml
@@ -24,8 +24,8 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
-        format_sql: true
-        show_sql: true
+        format_sql: false
+        show_sql: false
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
   kafka:


### PR DESCRIPTION
## 변경 타입

- [] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 테스트 항목

- [x] 코드가 의도한 대로 동작하는지 테스트 완료
- [ ] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음

## 변경 내용

- **as-is**
    - (변경 전 설명을 여기에 작성)

- **to-be**
    - 기존 API 방식으로 처리하던 결제 취소를 이벤트 방식으로 변경
    - ReservationCancel 이벤트 받아서 결제 취소 API 호출하도록 수정

## 참조
- resolve #279 
- [ET-157](https://challduck.atlassian.net/jira/software/projects/ET/boards/36?selectedIssue=ET-157)

## 코멘트

- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 예약 취소 이벤트를 처리하는 이벤트 기반 아키텍처 도입
  - Kafka 메시지 소비 및 에러 핸들링을 위한 Kafka Consumer 설정 추가
  - 예약 취소 이벤트 전용 페이로드 및 핸들러 추가

- **기능 개선**
  - 결제 취소 시 사용자 정보 일치 여부 검증 추가
  - 결제 정보 업데이트 시 승인 시간 필드(approvedAt) 추가 및 처리 로직 개선

- **버그 수정**
  - 불필요한 빈 클래스 및 REST 결제 취소 엔드포인트 제거

- **환경 설정**
  - Hibernate SQL 로그 출력 비활성화
  - Kafka dead-letter queue 및 재시도 정책 적용

- **예외 처리**
  - 결제 정보 불일치 및 비복구성 결제 예외 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->