### PR TITLE
[ET-170] feat(alarm) : 환경설정 및 기본 셋팅

### DIFF
--- a/alarm/build.gradle
+++ b/alarm/build.gradle
@@ -28,7 +28,9 @@ ext {
 }
 
 dependencies {
+    implementation project(':common')
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation "org.springframework.boot:spring-boot-starter-thymeleaf"
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.kafka:spring-kafka'
@@ -38,6 +40,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 dependencyManagement {

--- a/alarm/settings.gradle
+++ b/alarm/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'alarm'

--- a/alarm/src/main/java/com/earlybird/ticket/alarm/application/dispatcher/EventDispatcher.java
+++ b/alarm/src/main/java/com/earlybird/ticket/alarm/application/dispatcher/EventDispatcher.java
@@ -1,0 +1,8 @@
+package com.earlybird.ticket.alarm.application.dispatcher;
+
+import com.earlybird.ticket.alarm.domain.Event;
+import com.earlybird.ticket.common.entity.EventPayload;
+
+public interface EventDispatcher {
+    void handle(Event<? extends EventPayload> event);
+}

--- a/alarm/src/main/java/com/earlybird/ticket/alarm/application/dispatcher/EventDispatcherImpl.java
+++ b/alarm/src/main/java/com/earlybird/ticket/alarm/application/dispatcher/EventDispatcherImpl.java
@@ -1,0 +1,28 @@
+package com.earlybird.ticket.alarm.application.dispatcher;
+
+import com.earlybird.ticket.alarm.application.event.EventHandler;
+import com.earlybird.ticket.alarm.domain.Event;
+import com.earlybird.ticket.common.entity.EventPayload;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EventDispatcherImpl implements EventDispatcher {
+
+    private final List<EventHandler<? extends EventPayload>> handlerList;
+
+    @Override
+    public void handle(Event<? extends EventPayload> event) {
+        handlerList.stream()
+                   .filter(handler -> ((EventHandler) handler).support(event))
+                   .findFirst()
+                   .ifPresentOrElse(handler -> ((EventHandler) handler).handle(event),
+                                    () -> log.error("No handler found for event: {}",
+                                                    event.getEventType()));
+    }
+}

--- a/alarm/src/main/java/com/earlybird/ticket/alarm/application/event/EventHandler.java
+++ b/alarm/src/main/java/com/earlybird/ticket/alarm/application/event/EventHandler.java
@@ -1,0 +1,10 @@
+package com.earlybird.ticket.alarm.application.event;
+
+import com.earlybird.ticket.alarm.domain.Event;
+import com.earlybird.ticket.common.entity.EventPayload;
+
+public interface EventHandler<T extends EventPayload> {
+    void handle(Event<T> event);
+
+    boolean support(Event<T> event);
+}

--- a/alarm/src/main/java/com/earlybird/ticket/alarm/common/config/CommonConfig.java
+++ b/alarm/src/main/java/com/earlybird/ticket/alarm/common/config/CommonConfig.java
@@ -1,0 +1,10 @@
+package com.earlybird.ticket.alarm.common.config;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+@ComponentScan(basePackages = "com.earlybird.ticket.common")
+public class CommonConfig {
+}

--- a/alarm/src/main/java/com/earlybird/ticket/alarm/common/exception/CustomJsonProcessingException.java
+++ b/alarm/src/main/java/com/earlybird/ticket/alarm/common/exception/CustomJsonProcessingException.java
@@ -1,0 +1,11 @@
+package com.earlybird.ticket.alarm.common.exception;
+
+import com.earlybird.ticket.common.entity.constant.Code;
+import com.earlybird.ticket.common.exception.AbstractException;
+
+public class CustomJsonProcessingException extends AbstractException {
+    public CustomJsonProcessingException() {
+        super("json process exception",
+              Code.BAD_REQUEST);
+    }
+}

--- a/alarm/src/main/java/com/earlybird/ticket/alarm/common/exception/NonRecoverableReservationException.java
+++ b/alarm/src/main/java/com/earlybird/ticket/alarm/common/exception/NonRecoverableReservationException.java
@@ -1,0 +1,11 @@
+package com.earlybird.ticket.alarm.common.exception;
+
+import com.earlybird.ticket.common.entity.constant.Code;
+import com.earlybird.ticket.common.exception.AbstractException;
+
+public class NonRecoverableReservationException extends AbstractException {
+    public NonRecoverableReservationException() {
+        super("none recoverable reservation",
+              Code.NON_RECOVERABLE);
+    }
+}

--- a/alarm/src/main/java/com/earlybird/ticket/alarm/common/exception/RecoverableReservationException.java
+++ b/alarm/src/main/java/com/earlybird/ticket/alarm/common/exception/RecoverableReservationException.java
@@ -1,0 +1,11 @@
+package com.earlybird.ticket.alarm.common.exception;
+
+import com.earlybird.ticket.common.entity.constant.Code;
+import com.earlybird.ticket.common.exception.AbstractException;
+
+public class RecoverableReservationException extends AbstractException {
+    public RecoverableReservationException() {
+        super("Failed to earn Lock",
+              Code.RECOVERABLE);
+    }
+}

--- a/alarm/src/main/java/com/earlybird/ticket/alarm/common/util/EventPayloadConverter.java
+++ b/alarm/src/main/java/com/earlybird/ticket/alarm/common/util/EventPayloadConverter.java
@@ -1,0 +1,40 @@
+package com.earlybird.ticket.alarm.common.util;
+
+import com.earlybird.ticket.alarm.domain.Event;
+import com.earlybird.ticket.alarm.domain.constant.EventType;
+import com.earlybird.ticket.common.entity.EventPayload;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class EventPayloadConverter {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public String serializePayload(Event payload) {
+        try {
+            log.info("[CouponEventHandler] 직렬화된 FailCouponPayload: {}",
+                     payload);
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            log.error("[CouponEventHandler] FailCouponPayload 직렬화 실패",
+                      e);
+            throw new RuntimeException("Failed to serialize payload",
+                                       e);
+        }
+    }
+
+    public EventPayload deserializePayload(String payload,
+                                           EventType eventType) {
+        try {
+            return objectMapper.readValue(payload,
+                                          eventType.getPayloadClass());
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to deserialize payload",
+                                       e);
+        }
+    }
+}

--- a/alarm/src/main/java/com/earlybird/ticket/alarm/domain/Event.java
+++ b/alarm/src/main/java/com/earlybird/ticket/alarm/domain/Event.java
@@ -1,0 +1,64 @@
+package com.earlybird.ticket.alarm.domain;
+
+import com.earlybird.ticket.alarm.common.exception.CustomJsonProcessingException;
+import com.earlybird.ticket.alarm.domain.constant.EventType;
+import com.earlybird.ticket.common.entity.EventPayload;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Slf4j
+public class Event<T extends EventPayload> {
+    private EventType eventType;
+    private T payload;
+    private String timestamp;
+
+    @Builder
+    public Event(EventType eventType,
+                 T payload,
+                 String timestamp) {
+        this.eventType = eventType;
+        this.payload = payload;
+        this.timestamp = timestamp;
+    }
+
+
+    public static Event<? extends EventPayload> fromJson(String json) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode root = mapper.readTree(json);
+            log.info("[fromJson] root: {}",
+                     root);
+
+            String typeText = root.get("eventType")
+                                  .asText();
+            EventType eventType = EventType.from(typeText);
+            if (eventType == null)
+                throw new IllegalArgumentException("Unknown event type: " + typeText);
+            log.info("[fromJson] resolved eventType: {}",
+                     eventType);
+
+            String timestamp = root.get("timestamp")
+                                   .asText();
+            Class<? extends EventPayload> payloadClass = eventType.getPayloadClass();
+            log.info("[fromJson] payloadClass: {}",
+                     payloadClass.getName());
+
+            EventPayload payload = mapper.treeToValue(root.get("payload"),
+                                                      payloadClass);
+            return new Event<>(eventType,
+                               payload,
+                               timestamp);
+        } catch (Exception e) {
+            log.error("[fromJson] JSON 역직렬화 실패",
+                      e);
+            throw new CustomJsonProcessingException();
+        }
+    }
+}

--- a/alarm/src/main/java/com/earlybird/ticket/alarm/domain/Outbox.java
+++ b/alarm/src/main/java/com/earlybird/ticket/alarm/domain/Outbox.java
@@ -1,0 +1,71 @@
+package com.earlybird.ticket.alarm.domain;
+
+import com.earlybird.ticket.alarm.domain.constant.EventType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+// Outbox Entity 정의
+@Entity
+@Table(name = "p_outbox")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("success = false")
+public class Outbox {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String aggregateType;         // 예: "Order"
+
+    private UUID aggregateId;           // 예: 주문 ID
+
+    @Enumerated(EnumType.STRING)
+    private EventType eventType;          // 이벤트 타입
+
+    @Column(columnDefinition = "TEXT")
+    private String payload;               // 직렬화된 JSON 형태
+
+    private int retryCount;               // 재시도 횟수
+
+    private boolean success;              // 발행 성공 여부
+
+    private LocalDateTime createdAt;
+    private LocalDateTime sentAt;
+
+    @Builder
+    public Outbox(String aggregateType,
+                  UUID aggregateId,
+                  EventType eventType,
+                  String payload) {
+        this.aggregateType = aggregateType;
+        this.aggregateId = aggregateId;
+        this.eventType = eventType;
+        this.payload = payload;
+        this.retryCount = 0;
+        this.success = false;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void markSuccess() {
+        this.success = true;
+        this.sentAt = LocalDateTime.now();
+    }
+
+    public void incrementRetry() {
+        this.retryCount++;
+    }
+
+    public static class AggregateType {
+        public static final String RESERVATION = "RESERVATION";
+        public static final String COUPON = "COUPON";
+    }
+
+}

--- a/alarm/src/main/java/com/earlybird/ticket/alarm/domain/constant/EventType.java
+++ b/alarm/src/main/java/com/earlybird/ticket/alarm/domain/constant/EventType.java
@@ -1,0 +1,42 @@
+package com.earlybird.ticket.alarm.domain.constant;
+
+import com.earlybird.ticket.alarm.domain.dto.request.CreateAlarmEvent;
+import com.earlybird.ticket.common.entity.EventPayload;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+@RequiredArgsConstructor
+public enum EventType {
+
+
+    //Reservation -> Reservation(락 내 로직에서 발생한 DLT)
+    ALARM_CREATE_REQUEST(CreateAlarmEvent.class,
+                         Topic.VENUE_TO_ALARM_TOPIC);
+
+
+    private final Class<? extends EventPayload> payloadClass;
+    private final String topic;
+
+    public static EventType from(String type) {
+        try {
+            return valueOf(type);
+        } catch (Exception e) {
+            log.error("[EventType.from] type={} is invalid",
+                      type,
+                      e);
+            return null;
+        }
+    }
+
+    public static class Topic {
+
+        public static final String VENUE_TO_ALARM_TOPIC = "VenueToAlarm";
+        public static final String RESERVATION_TO_ALARM_TOPIC = "ReservationToAlarm";
+        public static final String PAYMENT_TO_ALARM_TOPIC = "PaymentToAlarm";
+
+
+    }
+}

--- a/alarm/src/main/java/com/earlybird/ticket/alarm/domain/dto/request/CreateAlarmEvent.java
+++ b/alarm/src/main/java/com/earlybird/ticket/alarm/domain/dto/request/CreateAlarmEvent.java
@@ -1,0 +1,6 @@
+package com.earlybird.ticket.alarm.domain.dto.request;
+
+import com.earlybird.ticket.common.entity.EventPayload;
+
+public class CreateAlarmEvent implements EventPayload {
+}

--- a/alarm/src/main/java/com/earlybird/ticket/alarm/domain/repository/OutboxRepository.java
+++ b/alarm/src/main/java/com/earlybird/ticket/alarm/domain/repository/OutboxRepository.java
@@ -1,0 +1,14 @@
+package com.earlybird.ticket.alarm.domain.repository;
+
+
+import com.earlybird.ticket.alarm.domain.Outbox;
+
+import java.util.List;
+
+public interface OutboxRepository {
+    Outbox save(Outbox outbox);
+
+    List<Outbox> findTOP100ByOrderByCreatedAtAsc();
+
+    void saveAll(List<Outbox> updatedOutboxes);
+}

--- a/alarm/src/main/java/com/earlybird/ticket/alarm/infrastructure/messaging/config/KafkaConfig.java
+++ b/alarm/src/main/java/com/earlybird/ticket/alarm/infrastructure/messaging/config/KafkaConfig.java
@@ -1,0 +1,11 @@
+package com.earlybird.ticket.alarm.infrastructure.messaging.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+
+@Configuration
+@EnableKafka
+public class KafkaConfig {
+
+
+}

--- a/alarm/src/main/java/com/earlybird/ticket/alarm/infrastructure/messaging/config/KafkaConsumerConfig.java
+++ b/alarm/src/main/java/com/earlybird/ticket/alarm/infrastructure/messaging/config/KafkaConsumerConfig.java
@@ -1,0 +1,113 @@
+package com.earlybird.ticket.alarm.infrastructure.messaging.config;
+
+import com.earlybird.ticket.alarm.common.exception.NonRecoverableReservationException;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.ExponentialBackOffWithMaxRetries;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+    Map<String, Object> props = new HashMap<>();
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @ConditionalOnMissingBean
+    public ConsumerFactory<String, String> consumerFactory() {
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                  bootstrapServers); // Kafka 브로커 리스트 설정
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                  StringDeserializer.class); // 메시지 키 역직렬화 방식 설정
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                  StringDeserializer.class); // 메시지 값 역직렬화 방식 설정
+        props.put(JsonDeserializer.TRUSTED_PACKAGES,
+                  "*"); // 신뢰할 수 있는 패키지 설정 (역직렬화 시 필요한 설정)
+
+        // Consumer 그룹 ID 설정 (여러 Consumer가 같은 그룹에서 동일한 메시지를 처리하지 않도록 함)
+        props.put(ConsumerConfig.GROUP_ID_CONFIG,
+                  "test-group-id");
+
+        // Offset 자동 커밋 비활성화 (중복 방지, 수동 커밋 사용)
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG,
+                  false);
+
+        // Kafka 컨슈머가 읽을 오프셋 위치 설정 (earliest: 가장 오래된 메시지부터 읽음, 기본값은 latest)
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
+                  "earliest");
+
+        // 한 번의 poll() 요청에서 가져올 최대 레코드 수 (성능 조절, 테스트하면서 수를 건드려야 할듯)
+        props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG,
+                  20);
+
+        // Poll 간격 최대 시간 (이 시간을 초과하면 Consumer 그룹에서 제거됨)
+        props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG,
+                  15000);
+
+        // Heartbeat 주기 (Consumer가 정상적으로 살아있음을 브로커에 알림)
+        props.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG,
+                  1000);
+
+        // Consumer가 장애로 인해 응답하지 않을 경우 제거되는 시간 (세션 타임아웃)
+        props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG,
+                  60000);
+
+        return new DefaultKafkaConsumerFactory<>(props,
+                                                 new StringDeserializer(),
+                                                 new StringDeserializer());
+    }
+
+    @Bean(name = "kafkaListenerContainerFactory")
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(DefaultErrorHandler defaultErrorHandler) {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+
+        // 메시지 처리 완료 즉시 커밋 (중복 방지)
+        factory.getContainerProperties()
+               .setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
+        factory.setCommonErrorHandler(defaultErrorHandler);
+
+        return factory;
+    }
+
+    @Bean
+    public DefaultErrorHandler errorHandler(KafkaTemplate<String, String> kafkaTemplate) {
+        // DLQ 설정
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(kafkaTemplate,
+                                                                                    (record, ex) -> {
+                                                                                        // 원본 토픽 이름에 .DLT 접미사 추가
+                                                                                        return new TopicPartition(record.topic() + ".DLT",
+                                                                                                                  record.partition());
+                                                                                    });
+        // 지터를 포함한 지수 백오프 설정 (최대 5회)
+        ExponentialBackOffWithMaxRetries backoff = new ExponentialBackOffWithMaxRetries(3);
+        backoff.setInitialInterval(2000); // 2초
+        backoff.setMultiplier(2.0);       // 2배씩 증가
+        backoff.setMaxInterval(10000);    // 최대 10초
+
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer,
+                                                                   backoff);
+
+        // 특정 예외는 재시도하지 않고 바로 DLQ로 보내고 싶을 때
+        // 이 예외는 재시도 하지 않고 바로 DLQ로 보냄
+        errorHandler.addNotRetryableExceptions(NonRecoverableReservationException.class,
+                                               IllegalArgumentException.class);
+
+        return errorHandler;
+    }
+}

--- a/alarm/src/main/java/com/earlybird/ticket/alarm/infrastructure/messaging/config/KafkaProducerConfig.java
+++ b/alarm/src/main/java/com/earlybird/ticket/alarm/infrastructure/messaging/config/KafkaProducerConfig.java
@@ -1,0 +1,80 @@
+package com.earlybird.ticket.alarm.infrastructure.messaging.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerInterceptor;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.ProducerListener;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> props = new HashMap<>();
+
+        // Kafka 서버 주소 설정
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                  bootstrapServers);
+
+        // Key와 Value 직렬화 설정 (Key는 String, Value는 JSON)
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                  StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                  StringSerializer.class);
+
+        // 메시지 중복 방지 (Idempotence 활성화 true면 멱등성 활성화)
+        props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG,
+                  true);
+
+        // 모든 리더(브로커)가 메시지를 받았을 때만 확인 응답 (최대 신뢰성) 내 ppt에 설명있음!
+        props.put(ProducerConfig.ACKS_CONFIG,
+                  "all");
+
+        // 실패 시 재시도 횟수 (최대 3번)
+        props.put(ProducerConfig.RETRIES_CONFIG,
+                  3);
+
+        // 동시 요청 개수 제한 (Idempotence 사용 시 5 이하 권장)
+        props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION,
+                  5);
+
+        // 배치 크기 (메시지를 일정 크기로 모아서 전송)
+        props.put(ProducerConfig.BATCH_SIZE_CONFIG,
+                  16384);
+
+        // 메시지 전송 전 대기 시간 (1ms 대기 후 전송)
+        props.put(ProducerConfig.LINGER_MS_CONFIG,
+                  1);
+
+        // 프로듀서가 버퍼링할 수 있는 메모리 크기 (32MB)
+        props.put(ProducerConfig.BUFFER_MEMORY_CONFIG,
+                  33554432);
+
+        // 메시지 압축 유형 설정 (gzip 사용)
+        props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG,
+                  "gzip");
+
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate(ProducerInterceptor<String, String> producerInterceptor,
+                                                       ProducerListener<String, String> producerListener) {
+        KafkaTemplate<String, String> kafkaTemplate = new KafkaTemplate<>(producerFactory());
+        kafkaTemplate.setProducerInterceptor(producerInterceptor);
+        kafkaTemplate.setProducerListener(producerListener);
+        return kafkaTemplate;
+    }
+}

--- a/alarm/src/main/java/com/earlybird/ticket/alarm/infrastructure/messaging/consumer/ReservationKafkaEventListener.java
+++ b/alarm/src/main/java/com/earlybird/ticket/alarm/infrastructure/messaging/consumer/ReservationKafkaEventListener.java
@@ -1,0 +1,38 @@
+package com.earlybird.ticket.alarm.infrastructure.messaging.consumer;
+
+import com.earlybird.ticket.alarm.application.dispatcher.EventDispatcher;
+import com.earlybird.ticket.alarm.common.exception.RecoverableReservationException;
+import com.earlybird.ticket.alarm.domain.Event;
+import com.earlybird.ticket.common.entity.EventPayload;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationKafkaEventListener {
+    private final EventDispatcher eventDispatcher;
+
+    @KafkaListener(topics = {}, containerFactory = "kafkaListenerContainerFactory")
+    public void listen(@Payload String message,
+                       Acknowledgment ack) {
+        try {
+            log.info("message = {} ",
+                     message);
+            //message 역직렬화
+            Event<? extends EventPayload> event = Event.fromJson(message);
+            eventDispatcher.handle(event);
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("메시지 처리 실패: {}",
+                      e.getMessage());
+            throw new RecoverableReservationException();
+        }
+    }
+
+}

--- a/alarm/src/main/java/com/earlybird/ticket/alarm/infrastructure/messaging/producer/KafkaProducerInterceptor.java
+++ b/alarm/src/main/java/com/earlybird/ticket/alarm/infrastructure/messaging/producer/KafkaProducerInterceptor.java
@@ -1,0 +1,86 @@
+package com.earlybird.ticket.alarm.infrastructure.messaging.producer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerInterceptor;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@Slf4j
+public class KafkaProducerInterceptor implements ProducerInterceptor<String, String> {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public ProducerRecord<String, String> onSend(ProducerRecord<String, String> producerRecord) {
+        log.info("onSend start");
+
+        Map<String, Object> logData = new HashMap<>();
+        logData.put("event",
+                    "kafka_send");
+        logData.put("topic",
+                    producerRecord.topic());
+        logData.put("key",
+                    producerRecord.key());
+        logData.put("value",
+                    producerRecord.value());
+        logData.put("timestamp",
+                    System.currentTimeMillis());
+
+        try {
+            log.info("Kafka Interceptor Log: {}",
+                     objectMapper.writeValueAsString(logData));
+        } catch (Exception e) {
+            log.error("Failed to serialize Kafka log data",
+                      e);
+        }
+
+        return producerRecord;
+    }
+
+    @Override
+    public void onAcknowledgement(RecordMetadata metadata,
+                                  Exception exception) {
+        log.info("onAcknowledgement start");
+
+        Map<String, Object> logData = new HashMap<>();
+        logData.put("event",
+                    "kafka_ack");
+        logData.put("topic",
+                    metadata.topic());
+        logData.put("partition",
+                    metadata.partition());
+        logData.put("offset",
+                    metadata.offset());
+        logData.put("timestamp",
+                    System.currentTimeMillis());
+
+        if (exception != null) {
+            logData.put("status",
+                        "failed");
+            logData.put("error",
+                        exception.getMessage());
+            log.error("Kafka Acknowledgement Error: {}",
+                      exception.getMessage());
+        } else {
+            logData.put("status",
+                        "success");
+            log.info("Kafka Acknowledgement Log: {}",
+                     logData);
+        }
+    }
+
+    @Override
+    public void close() {
+        log.info("Kafka ProducerInterceptor closed.");
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        log.info("Kafka ProducerInterceptor configured.");
+    }
+}

--- a/alarm/src/main/java/com/earlybird/ticket/alarm/infrastructure/messaging/producer/KafkaProducerListener.java
+++ b/alarm/src/main/java/com/earlybird/ticket/alarm/infrastructure/messaging/producer/KafkaProducerListener.java
@@ -1,0 +1,76 @@
+package com.earlybird.ticket.alarm.infrastructure.messaging.producer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.springframework.kafka.support.ProducerListener;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@Slf4j
+public class KafkaProducerListener implements ProducerListener<String, String> {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void onSuccess(ProducerRecord<String, String> producerRecord,
+                          RecordMetadata recordMetadata) {
+        Map<String, Object> logData = new HashMap<>();
+        logData.put("event",
+                    "kafka_success");
+        logData.put("topic",
+                    recordMetadata.topic());
+        logData.put("partition",
+                    recordMetadata.partition());
+        logData.put("offset",
+                    recordMetadata.offset());
+        logData.put("key",
+                    producerRecord.key());
+        logData.put("value",
+                    producerRecord.value());
+        logData.put("timestamp",
+                    System.currentTimeMillis());
+
+        try {
+            log.info("Kafka Success Log: {}",
+                     objectMapper.writeValueAsString(logData));
+        } catch (Exception e) {
+            log.error("Failed to serialize success log",
+                      e);
+        }
+    }
+
+    @Override
+    public void onError(ProducerRecord<String, String> producerRecord,
+                        RecordMetadata recordMetadata,
+                        Exception exception) {
+        Map<String, Object> logData = new HashMap<>();
+        logData.put("event",
+                    "kafka_error");
+        logData.put("topic",
+                    recordMetadata != null ? recordMetadata.topic() : "unknown");
+        logData.put("partition",
+                    recordMetadata != null ? recordMetadata.partition() : "unknown");
+        logData.put("offset",
+                    recordMetadata != null ? recordMetadata.offset() : "unknown");
+        logData.put("key",
+                    producerRecord.key());
+        logData.put("value",
+                    producerRecord.value());
+        logData.put("error",
+                    exception.getMessage());
+        logData.put("timestamp",
+                    System.currentTimeMillis());
+
+        try {
+            log.error("Kafka Error Log: {}",
+                      objectMapper.writeValueAsString(logData));
+        } catch (Exception e) {
+            log.error("Failed to serialize error log",
+                      e);
+        }
+    }
+}

--- a/alarm/src/main/java/com/earlybird/ticket/alarm/infrastructure/messaging/producer/ReservationKafkaOutboxProducer.java
+++ b/alarm/src/main/java/com/earlybird/ticket/alarm/infrastructure/messaging/producer/ReservationKafkaOutboxProducer.java
@@ -1,0 +1,83 @@
+package com.earlybird.ticket.alarm.infrastructure.messaging.producer;
+
+import com.earlybird.ticket.alarm.domain.Outbox;
+import com.earlybird.ticket.alarm.domain.repository.OutboxRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationKafkaOutboxProducer {
+
+    private static final String DLT_SUFFIX = ".DLT";
+
+    private final OutboxRepository outboxRepository;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    @Scheduled(fixedDelay = 7000)
+    @Transactional
+    public void publishPendingOutboxMessages() {
+        List<Outbox> pendingOutboxes = outboxRepository.findTOP100ByOrderByCreatedAtAsc();
+
+        List<CompletableFuture<Outbox>> futures = pendingOutboxes.stream()
+                                                                 .map(outbox -> {
+                                                                     String topic = Objects.requireNonNull(outbox.getEventType())
+                                                                                           .getTopic();
+                                                                     String key = outbox.getAggregateId()
+                                                                                        .toString();
+                                                                     String payload = outbox.getPayload();
+
+                                                                     log.info("[Outbox 발행] id = {}, topic = {}, payload = {}",
+                                                                              outbox.getId(),
+                                                                              topic,
+                                                                              payload);
+
+                                                                     return kafkaTemplate.send(topic,
+                                                                                               key,
+                                                                                               payload)
+                                                                                         .handle((res, ex) -> {
+                                                                                             if (ex != null) {
+                                                                                                 log.error("[발행 실패] id = {}, retryCount = {}",
+                                                                                                           outbox.getId(),
+                                                                                                           outbox.getRetryCount(),
+                                                                                                           ex);
+                                                                                                 outbox.incrementRetry();
+
+                                                                                                 if (outbox.getRetryCount() > 3) {
+                                                                                                     log.warn("[DLQ 이동] 3회 이상 실패한 이벤트 → {}",
+                                                                                                              outbox.getId());
+                                                                                                     kafkaTemplate.send(topic + DLT_SUFFIX,
+                                                                                                                        key,
+                                                                                                                        payload);
+                                                                                                 }
+                                                                                             } else {
+                                                                                                 outbox.markSuccess();
+                                                                                             }
+                                                                                             return outbox;
+                                                                                         });
+                                                                 })
+                                                                 .toList();
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                         .thenRun(() -> {
+                             List<Outbox> updatedOutboxes = futures.stream()
+                                                                   .map(CompletableFuture::join)
+                                                                   .toList();
+                             outboxRepository.saveAll(updatedOutboxes);
+                         })
+                         .exceptionally(ex -> {
+                             log.error("[Outbox 저장 중 예외 발생]",
+                                       ex);
+                             return null;
+                         });
+    }
+}

--- a/alarm/src/main/java/com/earlybird/ticket/alarm/infrastructure/repository/outbox/OutboxJpaRepository.java
+++ b/alarm/src/main/java/com/earlybird/ticket/alarm/infrastructure/repository/outbox/OutboxJpaRepository.java
@@ -1,0 +1,11 @@
+package com.earlybird.ticket.alarm.infrastructure.repository.outbox;
+
+import com.earlybird.ticket.alarm.domain.Outbox;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OutboxJpaRepository extends JpaRepository<Outbox, Long> {
+
+    List<Outbox> findTOP100ByOrderByCreatedAtAsc();
+}

--- a/alarm/src/main/java/com/earlybird/ticket/alarm/infrastructure/repository/outbox/OutboxRepositoryImpl.java
+++ b/alarm/src/main/java/com/earlybird/ticket/alarm/infrastructure/repository/outbox/OutboxRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.earlybird.ticket.alarm.infrastructure.repository.outbox;
+
+import com.earlybird.ticket.alarm.domain.Outbox;
+import com.earlybird.ticket.alarm.domain.repository.OutboxRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class OutboxRepositoryImpl implements OutboxRepository {
+    private final OutboxJpaRepository outboxJpaRepository;
+
+    @Override
+    public Outbox save(Outbox outbox) {
+        return outboxJpaRepository.save(outbox);
+    }
+
+    @Override
+    public List<Outbox> findTOP100ByOrderByCreatedAtAsc() {
+        return outboxJpaRepository.findTOP100ByOrderByCreatedAtAsc();
+    }
+
+    @Override
+    public void saveAll(List<Outbox> updatedOutboxes) {
+        outboxJpaRepository.saveAll(updatedOutboxes);
+    }
+
+}

--- a/alarm/src/main/resources/application.yml
+++ b/alarm/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
       idle-timeout: 30000
       connection-timeout: 30000
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://${POSTGRES_HOST:localhost}:${POSTGRES_RESERVATION_PORT:5432}/${POSTGRES_DB}
+    url: jdbc:postgresql://${POSTGRES_HOST:localhost}:${POSTGRES_ALARM_PORT:5432}/${POSTGRES_DB}
     username: ${POSTGRES_USER:postgres}
     password: ${POSTGRES_PASSWORD:postgres}
   kafka:

--- a/alarm/src/main/resources/application.yml
+++ b/alarm/src/main/resources/application.yml
@@ -1,3 +1,63 @@
 spring:
   application:
     name: alarm-service
+
+  jackson:
+    property-naming-strategy: SNAKE_CASE
+  config:
+    import: optional:file:.env[.properties]
+  data:
+  datasource:
+    hikari:
+      maximum-pool-size: 1000  # 기본은 10이라 너무 작음
+      minimum-idle: 10
+      idle-timeout: 30000
+      connection-timeout: 30000
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://${POSTGRES_HOST:localhost}:${POSTGRES_RESERVATION_PORT:5432}/${POSTGRES_DB}
+    username: ${POSTGRES_USER:postgres}
+    password: ${POSTGRES_PASSWORD:postgres}
+  kafka:
+    bootstrap-servers: ${KAFKA_HOST:localhost}:29092 #포트 및 호스트 수정 필요
+
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    hibernate:
+      ddl-auto: update
+    #    show-sql: true
+    open-in-view: false
+
+server:
+  port: 18092
+
+
+management:
+  endpoints:
+    jmx:
+      exposure:
+        include: prometheus
+    web:
+      exposure:
+        include: refresh,health,beans,busrefresh,info,metrics,prometheus
+  metrics:
+    distribution:
+      percentiles-histogram:
+        all: true
+  zipkin:
+    tracing:
+      endpoint: "http://${ZIPKIN_HOST:localhost}:${ZIPKIN_PORT:9411}/api/v2/spans"
+  tracing:
+    sampling:
+      probability: ${ZIPKIN_SAMPLING_PROBABILITY:1.0}
+
+
+eureka:
+  client:
+    fetch-registry: true
+    register-with-eureka: true
+    service-url:
+      defaultZone: http://${EUREKA_HOST:localhost}:${EUREKA_PORT:18080}/eureka
+    registry-fetch-interval-seconds: 10
+  instance:
+    lease-renewal-interval-in-seconds: 10
+    lease-expiration-duration-in-seconds: 30


### PR DESCRIPTION
## 변경 타입

- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 테스트 항목

- [x] 코드가 의도한 대로 동작하는지 테스트 완료
- [x] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음

## 변경 내용

- **as-is**
    - (변경 전 설명을 여기에 작성)

- **to-be**
    - 각 패키지 기본 설정
    - 아웃박스 구현

## 참조

[ET-170](https://challduck.atlassian.net/jira/software/projects/ET/boards/36?selectedIssue=ET-170)

## 코멘트


- 알람 토픽 설정 및 엔티티 내용 논의 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 이벤트 기반 알림 처리를 위한 이벤트, 아웃박스, 이벤트 디스패처, 핸들러 등 주요 도메인 및 유틸리티 클래스가 추가되었습니다.
  - Kafka 프로듀서 및 컨슈머 설정, 메시지 리스너, 프로듀서 인터셉터 및 리스너 등 메시징 관련 기능이 도입되었습니다.
  - 예약 관련 Kafka 메시지 수신 및 아웃박스 패턴 기반 메시지 발송 기능이 추가되었습니다.

- **버그 수정**
  - 해당 없음

- **설정**
  - Spring Boot, JPA, Thymeleaf, Validation 등 다양한 스타터 및 공통 모듈 의존성이 추가되었습니다.
  - PostgreSQL, Kafka, Eureka, Zipkin, 메트릭, 관리 엔드포인트 등 다양한 환경 설정이 application.yml에 반영되었습니다.

- **문서화**
  - 해당 없음

- **기타**
  - 프로젝트 설정 파일 일부가 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->