### PR TITLE
Feat(seat)/warm up seat instance

### DIFF
--- a/gateway/src/main/java/com/earlybird/ticket/gateway/infrastructure/config/SecurityWebConfig.java
+++ b/gateway/src/main/java/com/earlybird/ticket/gateway/infrastructure/config/SecurityWebConfig.java
@@ -51,8 +51,7 @@ public class SecurityWebConfig {
                 "api/v1/reservations/**",
                 "api/v1/concerts/**",
                 "api/v1/concertsequence/**",
-                "api/v1/coupons/**",
-                "api/v1/seats/**"
+                "api/v1/coupons/**"
             )
         );
 

--- a/gateway/src/main/java/com/earlybird/ticket/gateway/infrastructure/config/SecurityWebConfig.java
+++ b/gateway/src/main/java/com/earlybird/ticket/gateway/infrastructure/config/SecurityWebConfig.java
@@ -51,7 +51,8 @@ public class SecurityWebConfig {
                 "api/v1/reservations/**",
                 "api/v1/concerts/**",
                 "api/v1/concertsequence/**",
-                "api/v1/coupons/**"
+                "api/v1/coupons/**",
+                "api/v1/seats/**"
             )
         );
 

--- a/venue/src/main/java/com/earlybird/ticket/venue/application/service/SeatServiceImpl.java
+++ b/venue/src/main/java/com/earlybird/ticket/venue/application/service/SeatServiceImpl.java
@@ -19,6 +19,7 @@ import com.earlybird.ticket.venue.common.exception.TimeOutException;
 import com.earlybird.ticket.venue.domain.entity.Event;
 import com.earlybird.ticket.venue.domain.entity.Outbox;
 import com.earlybird.ticket.venue.domain.entity.Seat;
+import com.earlybird.ticket.venue.domain.entity.SeatInstance;
 import com.earlybird.ticket.venue.domain.entity.constant.Section;
 import com.earlybird.ticket.venue.domain.entity.constant.Status;
 import com.earlybird.ticket.venue.domain.repository.OutboxRepository;
@@ -27,15 +28,18 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RBucket;
 import org.redisson.api.RedissonClient;
+import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -48,6 +52,7 @@ public class SeatServiceImpl implements SeatService {
     private final OutboxRepository outboxRepository;
     private final EventConverter eventConverter;
     private final RedissonClient redissonClient;
+    private final StringRedisTemplate stringRedisTemplate;
     private final RedisTemplate<String, Object> redisTemplate;
     private final RedisScript<Object> seatPreemptScript;
 
@@ -86,7 +91,38 @@ public class SeatServiceImpl implements SeatService {
         return ProcessSeatCheckQuery.from(seatInstanceIdList, true);
     }
 
-    @Transactional
+    // TODO : 추후 배치로 고도화 고려 vs Kafka Consumer
+    @Scheduled(cron = "0 05 19 * * *", zone = "Asia/Seoul")
+    public void warmUpSeatInstance() {
+
+        //Mock Data
+        Map<UUID, LocalDateTime> todayTicketOpen = new HashMap<>();
+        todayTicketOpen.put(UUID.fromString("2d6d2381-a295-46fa-b798-a891f523c726"), LocalDateTime.now());
+        todayTicketOpen.put(UUID.fromString("52aab2c6-82e4-4c10-b983-e26bdb8550de"), LocalDateTime.now().minusMinutes(10));
+
+        List<UUID> concertSequenceIdList = new ArrayList<>(todayTicketOpen.keySet());
+
+        List<Seat> seats = seatRepository.findSeatListWithSeatInstanceInConcertSequenceIdList(concertSequenceIdList);
+
+        List<Object> results = stringRedisTemplate.executePipelined((RedisCallback<Object>) connection -> {
+            StringRedisConnection stringConn = (StringRedisConnection) connection;
+
+            for (Seat seat : seats) {
+                for (SeatInstance seatInstance : seat.getSeatInstances()) {
+                    String key = "SEAT_INSTANCE:" + seatInstance.getConcertSequenceId() + ":" + seatInstance.getId();
+                    stringConn.hSet(key, "status", seatInstance.getStatus().getValue());
+                    stringConn.hSet(key, "userId", "");
+                    stringConn.hSet(key, "reservationId", "");
+                    stringConn.hSet(key, "expireAt", CommonUtil.LocalDateTimetoString(todayTicketOpen.get(seatInstance.getConcertSequenceId())));
+                    stringConn.hSet(key, "updatedAt", "");
+                }
+            }
+
+            return null;
+        });
+
+    }
+
     public String preemptSeat(SeatPreemptCommand seatPreemptCommand, String passport) {
 
         PassportDto passportDto = passportUtil.getPassportDto(passport);

--- a/venue/src/main/java/com/earlybird/ticket/venue/domain/repository/SeatRepository.java
+++ b/venue/src/main/java/com/earlybird/ticket/venue/domain/repository/SeatRepository.java
@@ -24,4 +24,6 @@ public interface SeatRepository {
     Seat findSeatBySeatInstanceId(UUID seatInstanceId);
 
     List<Seat> findSeatListWithSeatInstanceByVenueId(UUID venueId);
+
+    List<Seat> findSeatListWithSeatInstanceInConcertSequenceIdList(List<UUID> concertSequenceIdList);
 }

--- a/venue/src/main/java/com/earlybird/ticket/venue/infrastructure/repository/SeatQueryRepository.java
+++ b/venue/src/main/java/com/earlybird/ticket/venue/infrastructure/repository/SeatQueryRepository.java
@@ -20,4 +20,6 @@ public interface SeatQueryRepository {
     Seat findSeatBySeatInstanceId(UUID seatInstanceId);
 
     List<Seat> findSeatListWithSeatInstanceByVenueId(UUID venueId);
+
+    List<Seat> findSeatListWithSeatInstanceInConcertSequenceIdList(List<UUID> concertSequenceIdList);
 }

--- a/venue/src/main/java/com/earlybird/ticket/venue/infrastructure/repository/SeatQueryRepositoryImpl.java
+++ b/venue/src/main/java/com/earlybird/ticket/venue/infrastructure/repository/SeatQueryRepositoryImpl.java
@@ -165,4 +165,18 @@ public class SeatQueryRepositoryImpl implements SeatQueryRepository {
                 )
                 .fetch();
     }
+
+    @Override
+    public List<Seat> findSeatListWithSeatInstanceInConcertSequenceIdList(List<UUID> concertSequenceIdList) {
+        return queryFactory
+                .selectDistinct(seat)
+                .from(seat)
+                .join(seat.seatInstances, seatInstance).fetchJoin()
+                .where(
+                        seatInstance.concertSequenceId.in(concertSequenceIdList),
+                        seatInstance.deletedAt.isNull(),
+                        seat.deletedAt.isNull()
+                )
+                .fetch();
+    }
 }

--- a/venue/src/main/java/com/earlybird/ticket/venue/infrastructure/repository/SeatRepositoryImpl.java
+++ b/venue/src/main/java/com/earlybird/ticket/venue/infrastructure/repository/SeatRepositoryImpl.java
@@ -52,4 +52,9 @@ public class SeatRepositoryImpl implements SeatRepository {
     public List<Seat> findSeatListWithSeatInstanceByVenueId(UUID venueId) {
         return seatQueryRepository.findSeatListWithSeatInstanceByVenueId(venueId);
     }
+
+    @Override
+    public List<Seat> findSeatListWithSeatInstanceInConcertSequenceIdList(List<UUID> concertSequenceIdList) {
+        return seatQueryRepository.findSeatListWithSeatInstanceInConcertSequenceIdList(concertSequenceIdList);
+    }
 }

--- a/venue/src/main/java/com/earlybird/ticket/venue/presentation/controller/SeatController.java
+++ b/venue/src/main/java/com/earlybird/ticket/venue/presentation/controller/SeatController.java
@@ -67,7 +67,7 @@ public class SeatController {
         );
     }
 
-    @PostMapping
+    @PostMapping("/preempt")
     public ResponseEntity<CommonDto<String>> preemptSeat(
             @RequestHeader("X-User-Passport") String passport,
             @RequestBody @Valid SeatPreemptRequest seatPreemptRequest

--- a/venue/src/main/resources/application.yml
+++ b/venue/src/main/resources/application.yml
@@ -17,12 +17,12 @@ spring:
       query:
         in_clause_parameter_padding: false
       ddl-auto: update
-    show-sql: false
+    show-sql: true
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     properties:
       hibernate:
         default_batch_fetch_size: 1000
-        format_sql: true
+        format_sql: false
   datasource:
     hikari:
       maximum-pool-size: 1000


### PR DESCRIPTION
## 변경 타입

- [x] 신규 기능 추가/수정
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 테스트 항목

- [x] 코드가 의도한 대로 동작하는지 테스트 완료
- [ ] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음

## 변경 내용

- **as-is**
    - (변경 전 설명을 여기에 작성)

- **to-be**
    - 데이터 redis로 warm-up
    - redisConfig 수정
    - 파라미터 타입 수정

## 참조

[ET-173](https://challduck.atlassian.net/jira/software/projects/ET/boards/36?selectedIssue=ET-173)

## 코멘트

- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 좌석 인스턴스 정보를 사전에 Redis에 적재하는 예약 작업이 매일 19:05(서울 기준)에 자동 실행됩니다.
    - 여러 콘서트 시퀀스 ID로 좌석 및 좌석 인스턴스 목록을 조회하는 기능이 추가되었습니다.

- **버그 수정**
    - 좌석 선점 API 엔드포인트가 `/api/v1/external/seats/preempt`로 변경되었습니다.

- **보안**
    - `/api/v1/seats/**` 경로에 대한 인증이 필수로 적용됩니다.

- **설정**
    - JPA SQL 로그가 출력되도록 변경되었습니다(포맷팅은 비활성화).

- **성능 개선**
    - Redis 연동 및 Lua 스크립트 실행이 최적화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->