### PR TITLE
[ET-183] Outbox 마이그레이션 작업 추가

### DIFF
--- a/batch/src/main/java/com/earlybird/ticket/batch/domain/entity/Outbox.java
+++ b/batch/src/main/java/com/earlybird/ticket/batch/domain/entity/Outbox.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -19,11 +20,20 @@ import org.hibernate.annotations.SQLRestriction;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLRestriction("success is false")
+@SequenceGenerator(
+    name = "OUTBOX_SEQ_GENERATOR",
+    sequenceName = "P_OUTBOX_SEQ",
+    initialValue = 1, allocationSize = 100
+)
 public class Outbox {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE,
+        generator = "OUTBOX_SEQ_GENERATOR")
     private Long id;
+
+    @Column(name = "org_id")
+    private Long orgId; // 각 서비스에서의 ID
 
     private String aggregateType;
 
@@ -42,9 +52,9 @@ public class Outbox {
 
     private LocalDateTime sentAt;
 
-    @Builder
+    @Builder(builderMethodName = "withoutId")
     public Outbox(
-        Long id,
+        Long orgId,
         String aggregateType,
         UUID aggregateId,
         String eventType,
@@ -54,7 +64,7 @@ public class Outbox {
         LocalDateTime createdAt,
         LocalDateTime sentAt
     ) {
-        this.id = id;
+        this.orgId = orgId;
         this.aggregateType = aggregateType;
         this.aggregateId = aggregateId;
         this.eventType = eventType;

--- a/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/OutboxCollectBatchConfig.java
+++ b/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/OutboxCollectBatchConfig.java
@@ -53,14 +53,14 @@ public class OutboxCollectBatchConfig {
         SqlPagingQueryProviderFactoryBean queryProvider = new SqlPagingQueryProviderFactoryBean();
         queryProvider.setDataSource(dataSource);
         queryProvider.setSelectClause("""
-            SELECT o.aggregate_type, o.aggregate_id, o.event_type, o.payload, o.retry_count,
+            SELECT o.id, o.aggregate_type, o.aggregate_id, o.event_type, o.payload, o.retry_count,
             o.success, o.created_at, o.sent_at
             """);
         queryProvider.setFromClause("FROM p_outbox o");
         queryProvider.setWhereClause(
-            "WHERE o.success = true or (o.retry_count >= 3 and o.success = false)");
+            "WHERE o.success = true or (o.success = false and o.retry_count >= 3)");
         queryProvider.setSortKeys(Map.of(
-            "created_at", Order.ASCENDING,
+            "id", Order.ASCENDING,
             "sent_at", Order.ASCENDING
         ));
         return queryProvider.getObject();

--- a/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/OutboxItemSqlParameterSourceProvider.java
+++ b/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/OutboxItemSqlParameterSourceProvider.java
@@ -1,0 +1,16 @@
+package com.earlybird.ticket.batch.infrastructure.config.jdbc;
+
+import com.earlybird.ticket.batch.domain.entity.Outbox;
+import org.springframework.batch.item.database.ItemSqlParameterSourceProvider;
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+
+
+public class OutboxItemSqlParameterSourceProvider implements
+    ItemSqlParameterSourceProvider<Outbox> {
+
+    @Override
+    public SqlParameterSource createSqlParameterSource(Outbox item) {
+        return new BeanPropertySqlParameterSource(item);
+    }
+}

--- a/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/dto/response/OutboxMessage.java
+++ b/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/dto/response/OutboxMessage.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 
 @Builder
 public record OutboxMessage(
+    Long id,
     String aggregateType,
     UUID aggregateId,
     String eventType,

--- a/batch/src/main/resources/application.yml
+++ b/batch/src/main/resources/application.yml
@@ -33,6 +33,9 @@ spring:
       ddl-auto: update
     properties:
       hibernate:
+        jdbc:
+          batch_size: 100
+        order_inserts: true
         dialect: org.hibernate.dialect.PostgreSQLDialect
         show_sql: true
         format_sql: true


### PR DESCRIPTION
## 변경 타입

- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 테스트 항목

- [x] 코드가 의도한 대로 동작하는지 테스트 완료
- [ ] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음

## 변경 내용

- **as-is**
    - (변경 전 설명을 여기에 작성)

- **to-be**
    - 복사와 삭제 모두 수행하도록 `CompositeItemWriter` 추가
    - chunkSize 1000, batchSize 100으로 수정
    - postgresql의 sequence 활용해 id값 채우도록 수정

## 참조

[ET-183](https://challduck.atlassian.net/jira/software/projects/ET/boards/36?selectedIssue=ET-183)

## 코멘트

- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - Outbox 엔터티에 orgId 필드가 추가되어 각 서비스의 ID를 저장할 수 있습니다.
    - OutboxMessage에 id 필드가 추가되었습니다.

- **버그 수정**
    - Outbox 엔터티의 ID 생성 전략이 시퀀스 기반으로 변경되어 데이터베이스 일관성이 향상되었습니다.

- **성능 개선**
    - JPA 기반에서 JDBC 배치 기반 아웃박스 마이그레이션으로 전환되어 데이터 이동 성능이 개선되었습니다.
    - Hibernate JDBC 배치 처리 및 insert 정렬 옵션이 활성화되어 대량 데이터 처리 효율이 향상되었습니다.

- **기타**
    - Outbox 객체를 JDBC에서 사용할 수 있도록 SqlParameterSourceProvider가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->