### PR TITLE
Feat(batch)/gather each service outbox

### DIFF
--- a/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/AdminStepConfig.java
+++ b/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/AdminStepConfig.java
@@ -65,7 +65,7 @@ public class AdminStepConfig {
     }
 
     @Bean
-    public CompositeItemWriter<Outbox> concertOutboxMigrateWriter(
+    public CompositeItemWriter<Outbox> adminOutboxMigrateWriter(
         DataSource sinkDataSource,
         DataSource adminDataSource
     ) {
@@ -107,11 +107,11 @@ public class AdminStepConfig {
         @Qualifier("adminDataSource") DataSource adminDataSource,
         @Qualifier("sinkDataSource") DataSource sinkDataSource
     ) throws Exception {
-        return new StepBuilder("venueOutboxCollectStep", jobRepository)
+        return new StepBuilder("adminOutboxCollectStep", jobRepository)
             .<OutboxMessage, Outbox>chunk(CHUNK_SIZE, transactionManager)
             .reader(adminOutboxReader(adminDataSource))
             .processor(sinkOutboxProcessor)
-            .writer(concertOutboxMigrateWriter(sinkDataSource, adminDataSource))
+            .writer(adminOutboxMigrateWriter(sinkDataSource, adminDataSource))
             .build();
     }
 }

--- a/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/AdminStepConfig.java
+++ b/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/AdminStepConfig.java
@@ -1,0 +1,117 @@
+package com.earlybird.ticket.batch.infrastructure.config.jdbc;
+
+import static com.earlybird.ticket.batch.infrastructure.config.jdbc.OutboxCollectBatchConfig.CHUNK_SIZE;
+
+import com.earlybird.ticket.batch.domain.entity.Outbox;
+import com.earlybird.ticket.batch.infrastructure.dto.response.OutboxMessage;
+import java.util.Map;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.JdbcPagingItemReader;
+import org.springframework.batch.item.database.Order;
+import org.springframework.batch.item.database.PagingQueryProvider;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+import org.springframework.batch.item.database.builder.JdbcPagingItemReaderBuilder;
+import org.springframework.batch.item.database.support.SqlPagingQueryProviderFactoryBean;
+import org.springframework.batch.item.support.CompositeItemWriter;
+import org.springframework.batch.item.support.builder.CompositeItemWriterBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.DataClassRowMapper;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class AdminStepConfig {
+
+    private final ItemProcessor<OutboxMessage, Outbox> sinkOutboxProcessor;
+
+    @Bean
+    @Qualifier("adminOutboxReader")
+    public JdbcPagingItemReader<OutboxMessage> adminOutboxReader(DataSource dataSource)
+        throws Exception {
+        return new JdbcPagingItemReaderBuilder<OutboxMessage>()
+            .name("adminOutboxReader")
+            .dataSource(dataSource)
+            .fetchSize(CHUNK_SIZE)
+            .pageSize(CHUNK_SIZE)
+            // 기본 생성자 대신 모든 필드를 지닌 생성자 매핑
+            .rowMapper(new DataClassRowMapper<>(OutboxMessage.class))
+            .queryProvider(adminQueryProvider(dataSource))
+            .build();
+    }
+
+    @Bean
+    public PagingQueryProvider adminQueryProvider(DataSource dataSource) throws Exception {
+        SqlPagingQueryProviderFactoryBean queryProvider = new SqlPagingQueryProviderFactoryBean();
+        queryProvider.setDataSource(dataSource);
+        queryProvider.setSelectClause("""
+            SELECT o.id, o.aggregate_type, o.aggregate_id, o.event_type, o.payload, o.retry_count,
+            o.success, o.created_at, o.sent_at
+            """);
+        queryProvider.setFromClause("FROM p_outbox o");
+        queryProvider.setWhereClause(
+            "WHERE o.success = true or (o.success = false and o.retry_count >= 3)");
+        queryProvider.setSortKeys(Map.of(
+            "id", Order.ASCENDING
+        ));
+        return queryProvider.getObject();
+    }
+
+    @Bean
+    public CompositeItemWriter<Outbox> concertOutboxMigrateWriter(
+        DataSource sinkDataSource,
+        DataSource adminDataSource
+    ) {
+
+        OutboxItemSqlParameterSourceProvider outboxParameterSource = new OutboxItemSqlParameterSourceProvider();
+        // payment -> sink로 복사
+        JdbcBatchItemWriter<Outbox> writeToSink = new JdbcBatchItemWriterBuilder<Outbox>()
+            .dataSource(sinkDataSource)
+            .sql("""
+                INSERT INTO p_outbox(id, aggregate_type, aggregate_id, event_type, payload, retry_count, success, created_at, sent_at, org_id)
+                VALUES (nextval('p_outbox_seq'), :aggregateType, :aggregateId, :eventType, :payload, :retryCount, :success, :createdAt, :sentAt, :orgId)
+                """)
+            .itemSqlParameterSourceProvider(outboxParameterSource)
+            .build();
+        writeToSink.afterPropertiesSet();
+
+        // payment에서 삭제
+        JdbcBatchItemWriter<Outbox> deleteAdminOutbox = new JdbcBatchItemWriterBuilder<Outbox>()
+            .dataSource(adminDataSource)
+            .sql("""
+                DELETE FROM p_outbox where id = :orgId
+                """)
+            .itemSqlParameterSourceProvider(outboxParameterSource)
+            .build();
+        deleteAdminOutbox.afterPropertiesSet();
+
+        return new CompositeItemWriterBuilder<Outbox>()
+            .delegates(writeToSink, deleteAdminOutbox)
+            .build();
+    }
+
+    /* TODO : TransactionManager 변경
+        현재는 sink의 트랜잭션매니저만 가지고 있어 source에서는 롤백 발생 X
+     */
+    @Bean
+    public Step collectAdminOutboxStep(
+        JobRepository jobRepository,
+        @Qualifier("sinkTransactionManager") PlatformTransactionManager transactionManager,
+        @Qualifier("adminDataSource") DataSource adminDataSource,
+        @Qualifier("sinkDataSource") DataSource sinkDataSource
+    ) throws Exception {
+        return new StepBuilder("venueOutboxCollectStep", jobRepository)
+            .<OutboxMessage, Outbox>chunk(CHUNK_SIZE, transactionManager)
+            .reader(adminOutboxReader(adminDataSource))
+            .processor(sinkOutboxProcessor)
+            .writer(concertOutboxMigrateWriter(sinkDataSource, adminDataSource))
+            .build();
+    }
+}

--- a/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/ConcertStepConfig.java
+++ b/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/ConcertStepConfig.java
@@ -107,7 +107,7 @@ public class ConcertStepConfig {
         @Qualifier("concertDataSource") DataSource concertDataSource,
         @Qualifier("sinkDataSource") DataSource sinkDataSource
     ) throws Exception {
-        return new StepBuilder("paymentOutboxCollectStep", jobRepository)
+        return new StepBuilder("concertOutboxCollectStep", jobRepository)
             .<OutboxMessage, Outbox>chunk(CHUNK_SIZE, transactionManager)
             .reader(concertOutboxReader(concertDataSource))
             .processor(sinkOutboxProcessor)

--- a/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/ConcertStepConfig.java
+++ b/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/ConcertStepConfig.java
@@ -1,0 +1,117 @@
+package com.earlybird.ticket.batch.infrastructure.config.jdbc;
+
+import static com.earlybird.ticket.batch.infrastructure.config.jdbc.OutboxCollectBatchConfig.CHUNK_SIZE;
+
+import com.earlybird.ticket.batch.domain.entity.Outbox;
+import com.earlybird.ticket.batch.infrastructure.dto.response.OutboxMessage;
+import java.util.Map;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.JdbcPagingItemReader;
+import org.springframework.batch.item.database.Order;
+import org.springframework.batch.item.database.PagingQueryProvider;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+import org.springframework.batch.item.database.builder.JdbcPagingItemReaderBuilder;
+import org.springframework.batch.item.database.support.SqlPagingQueryProviderFactoryBean;
+import org.springframework.batch.item.support.CompositeItemWriter;
+import org.springframework.batch.item.support.builder.CompositeItemWriterBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.DataClassRowMapper;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class ConcertStepConfig {
+
+    private final ItemProcessor<OutboxMessage, Outbox> sinkOutboxProcessor;
+
+    @Bean
+    @Qualifier("concertOutboxReader")
+    public JdbcPagingItemReader<OutboxMessage> concertOutboxReader(DataSource dataSource)
+        throws Exception {
+        return new JdbcPagingItemReaderBuilder<OutboxMessage>()
+            .name("concertOutboxReader")
+            .dataSource(dataSource)
+            .fetchSize(CHUNK_SIZE)
+            .pageSize(CHUNK_SIZE)
+            // 기본 생성자 대신 모든 필드를 지닌 생성자 매핑
+            .rowMapper(new DataClassRowMapper<>(OutboxMessage.class))
+            .queryProvider(concertQueryProvider(dataSource))
+            .build();
+    }
+
+    @Bean
+    public PagingQueryProvider concertQueryProvider(DataSource dataSource) throws Exception {
+        SqlPagingQueryProviderFactoryBean queryProvider = new SqlPagingQueryProviderFactoryBean();
+        queryProvider.setDataSource(dataSource);
+        queryProvider.setSelectClause("""
+            SELECT o.id, o.aggregate_type, o.aggregate_id, o.event_type, o.payload, o.retry_count,
+            o.success, o.created_at, o.sent_at
+            """);
+        queryProvider.setFromClause("FROM p_outbox o");
+        queryProvider.setWhereClause(
+            "WHERE o.success = true or (o.success = false and o.retry_count >= 3)");
+        queryProvider.setSortKeys(Map.of(
+            "id", Order.ASCENDING
+        ));
+        return queryProvider.getObject();
+    }
+
+    @Bean
+    public CompositeItemWriter<Outbox> concertOutboxMigrateWriter(
+        DataSource sinkDataSource,
+        DataSource concertDataSource
+    ) {
+
+        OutboxItemSqlParameterSourceProvider outboxParameterSource = new OutboxItemSqlParameterSourceProvider();
+        // payment -> sink로 복사
+        JdbcBatchItemWriter<Outbox> writeToSink = new JdbcBatchItemWriterBuilder<Outbox>()
+            .dataSource(sinkDataSource)
+            .sql("""
+                INSERT INTO p_outbox(id, aggregate_type, aggregate_id, event_type, payload, retry_count, success, created_at, sent_at, org_id)
+                VALUES (nextval('p_outbox_seq'), :aggregateType, :aggregateId, :eventType, :payload, :retryCount, :success, :createdAt, :sentAt, :orgId)
+                """)
+            .itemSqlParameterSourceProvider(outboxParameterSource)
+            .build();
+        writeToSink.afterPropertiesSet();
+
+        // payment에서 삭제
+        JdbcBatchItemWriter<Outbox> deleteConcertOutbox = new JdbcBatchItemWriterBuilder<Outbox>()
+            .dataSource(concertDataSource)
+            .sql("""
+                DELETE FROM p_outbox where id = :orgId
+                """)
+            .itemSqlParameterSourceProvider(outboxParameterSource)
+            .build();
+        deleteConcertOutbox.afterPropertiesSet();
+
+        return new CompositeItemWriterBuilder<Outbox>()
+            .delegates(writeToSink, deleteConcertOutbox)
+            .build();
+    }
+
+    /* TODO : TransactionManager 변경
+        현재는 sink의 트랜잭션매니저만 가지고 있어 source에서는 롤백 발생 X
+     */
+    @Bean
+    public Step collectConcertOutboxStep(
+        JobRepository jobRepository,
+        @Qualifier("sinkTransactionManager") PlatformTransactionManager transactionManager,
+        @Qualifier("concertDataSource") DataSource concertDataSource,
+        @Qualifier("sinkDataSource") DataSource sinkDataSource
+    ) throws Exception {
+        return new StepBuilder("paymentOutboxCollectStep", jobRepository)
+            .<OutboxMessage, Outbox>chunk(CHUNK_SIZE, transactionManager)
+            .reader(concertOutboxReader(concertDataSource))
+            .processor(sinkOutboxProcessor)
+            .writer(concertOutboxMigrateWriter(sinkDataSource, concertDataSource))
+            .build();
+    }
+}

--- a/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/CouponStepConfig.java
+++ b/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/CouponStepConfig.java
@@ -1,0 +1,117 @@
+package com.earlybird.ticket.batch.infrastructure.config.jdbc;
+
+import static com.earlybird.ticket.batch.infrastructure.config.jdbc.OutboxCollectBatchConfig.CHUNK_SIZE;
+
+import com.earlybird.ticket.batch.domain.entity.Outbox;
+import com.earlybird.ticket.batch.infrastructure.dto.response.OutboxMessage;
+import java.util.Map;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.JdbcPagingItemReader;
+import org.springframework.batch.item.database.Order;
+import org.springframework.batch.item.database.PagingQueryProvider;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+import org.springframework.batch.item.database.builder.JdbcPagingItemReaderBuilder;
+import org.springframework.batch.item.database.support.SqlPagingQueryProviderFactoryBean;
+import org.springframework.batch.item.support.CompositeItemWriter;
+import org.springframework.batch.item.support.builder.CompositeItemWriterBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.DataClassRowMapper;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class CouponStepConfig {
+
+    private final ItemProcessor<OutboxMessage, Outbox> sinkOutboxProcessor;
+
+    @Bean
+    @Qualifier("CouponOutboxReader")
+    public JdbcPagingItemReader<OutboxMessage> couponOutboxReader(DataSource dataSource)
+        throws Exception {
+        return new JdbcPagingItemReaderBuilder<OutboxMessage>()
+            .name("couponOutboxReader")
+            .dataSource(dataSource)
+            .fetchSize(CHUNK_SIZE)
+            .pageSize(CHUNK_SIZE)
+            // 기본 생성자 대신 모든 필드를 지닌 생성자 매핑
+            .rowMapper(new DataClassRowMapper<>(OutboxMessage.class))
+            .queryProvider(couponQueryProvider(dataSource))
+            .build();
+    }
+
+    @Bean
+    public PagingQueryProvider couponQueryProvider(DataSource dataSource) throws Exception {
+        SqlPagingQueryProviderFactoryBean queryProvider = new SqlPagingQueryProviderFactoryBean();
+        queryProvider.setDataSource(dataSource);
+        queryProvider.setSelectClause("""
+            SELECT o.id, o.aggregate_type, o.aggregate_id, o.event_type, o.payload, o.retry_count,
+            o.success, o.created_at, o.sent_at
+            """);
+        queryProvider.setFromClause("FROM p_outbox o");
+        queryProvider.setWhereClause(
+            "WHERE o.success = true or (o.success = false and o.retry_count >= 3)");
+        queryProvider.setSortKeys(Map.of(
+            "id", Order.ASCENDING
+        ));
+        return queryProvider.getObject();
+    }
+
+    @Bean
+    public CompositeItemWriter<Outbox> couponOutboxMigrateWriter(
+        DataSource sinkDataSource,
+        DataSource couponDataSource
+    ) {
+
+        OutboxItemSqlParameterSourceProvider outboxParameterSource = new OutboxItemSqlParameterSourceProvider();
+        // payment -> sink로 복사
+        JdbcBatchItemWriter<Outbox> writeToSink = new JdbcBatchItemWriterBuilder<Outbox>()
+            .dataSource(sinkDataSource)
+            .sql("""
+                INSERT INTO p_outbox(id, aggregate_type, aggregate_id, event_type, payload, retry_count, success, created_at, sent_at, org_id)
+                VALUES (nextval('p_outbox_seq'), :aggregateType, :aggregateId, :eventType, :payload, :retryCount, :success, :createdAt, :sentAt, :orgId)
+                """)
+            .itemSqlParameterSourceProvider(outboxParameterSource)
+            .build();
+        writeToSink.afterPropertiesSet();
+
+        // payment에서 삭제
+        JdbcBatchItemWriter<Outbox> deleteCouponOutbox = new JdbcBatchItemWriterBuilder<Outbox>()
+            .dataSource(couponDataSource)
+            .sql("""
+                DELETE FROM p_outbox where id = :orgId
+                """)
+            .itemSqlParameterSourceProvider(outboxParameterSource)
+            .build();
+        deleteCouponOutbox.afterPropertiesSet();
+
+        return new CompositeItemWriterBuilder<Outbox>()
+            .delegates(writeToSink, deleteCouponOutbox)
+            .build();
+    }
+
+    /* TODO : TransactionManager 변경
+        현재는 sink의 트랜잭션매니저만 가지고 있어 source에서는 롤백 발생 X
+     */
+    @Bean
+    public Step collectCouponOutboxStep(
+        JobRepository jobRepository,
+        @Qualifier("sinkTransactionManager") PlatformTransactionManager transactionManager,
+        @Qualifier("couponDataSource") DataSource couponDataSource,
+        @Qualifier("sinkDataSource") DataSource sinkDataSource
+    ) throws Exception {
+        return new StepBuilder("couponOutboxCollectStep", jobRepository)
+            .<OutboxMessage, Outbox>chunk(CHUNK_SIZE, transactionManager)
+            .reader(couponOutboxReader(couponDataSource))
+            .processor(sinkOutboxProcessor)
+            .writer(couponOutboxMigrateWriter(sinkDataSource, couponDataSource))
+            .build();
+    }
+}

--- a/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/OutboxCollectBatchConfig.java
+++ b/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/OutboxCollectBatchConfig.java
@@ -2,30 +2,16 @@ package com.earlybird.ticket.batch.infrastructure.config.jdbc;
 
 import com.earlybird.ticket.batch.domain.entity.Outbox;
 import com.earlybird.ticket.batch.infrastructure.dto.response.OutboxMessage;
-import java.util.Map;
-import javax.sql.DataSource;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.launch.support.RunIdIncrementer;
 import org.springframework.batch.core.repository.JobRepository;
-import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.item.ItemProcessor;
-import org.springframework.batch.item.database.JdbcBatchItemWriter;
-import org.springframework.batch.item.database.JdbcPagingItemReader;
-import org.springframework.batch.item.database.Order;
-import org.springframework.batch.item.database.PagingQueryProvider;
-import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
-import org.springframework.batch.item.database.builder.JdbcPagingItemReaderBuilder;
-import org.springframework.batch.item.database.support.SqlPagingQueryProviderFactoryBean;
-import org.springframework.batch.item.support.CompositeItemWriter;
-import org.springframework.batch.item.support.builder.CompositeItemWriterBuilder;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.jdbc.core.DataClassRowMapper;
-import org.springframework.transaction.PlatformTransactionManager;
 
 @Slf4j
 @Configuration
@@ -49,20 +35,25 @@ public class OutboxCollectBatchConfig {
             .build();
     }
 
-    /*
-     * TODO : admin, concert, coupon, reservation, venue 추가
-     *  1. ItemReader 빈 추가
-     *  2. QueryProvider 추가
-     *  3. ItemWriter 빈 추가
-     *  4. 각 서비스 step으로 빈 추가
-     *  5. Job에 각 서비스 Step 연결
-     */
     @Bean
-    public Job collectOutboxJob(Step collectPaymentOutboxStep, JobRepository jobRepository) {
+    public Job collectOutboxJob(
+        @Qualifier("collectPaymentOutboxStep") Step collectPaymentOutboxStep,
+        @Qualifier("collectCouponOutboxStep") Step collectCouponOutboxStep,
+        @Qualifier("collectConcertOutboxStep") Step collectConcertOutboxStep,
+        @Qualifier("collectVenueOutboxStep") Step collectVenueOutboxStep,
+        @Qualifier("collectAdminOutboxStep") Step collectAdminOutboxStep,
+        @Qualifier("collectReservationOutboxStep") Step collectReservationOutboxStep,
+        JobRepository jobRepository
+    ) {
         // TODO : step으로 admin, concert, coupon, reservation, venue 추가
         return new JobBuilder(OUTBOX_COLLECT_JOB, jobRepository)
             .incrementer(new RunIdIncrementer())
             .start(collectPaymentOutboxStep)
+            .next(collectCouponOutboxStep)
+            .next(collectConcertOutboxStep)
+            .next(collectVenueOutboxStep)
+            .next(collectAdminOutboxStep)
+            .next(collectReservationOutboxStep)
             .build();
     }
 }

--- a/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/PaymentStepConfig.java
+++ b/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/PaymentStepConfig.java
@@ -1,0 +1,117 @@
+package com.earlybird.ticket.batch.infrastructure.config.jdbc;
+
+import static com.earlybird.ticket.batch.infrastructure.config.jdbc.OutboxCollectBatchConfig.*;
+
+import com.earlybird.ticket.batch.domain.entity.Outbox;
+import com.earlybird.ticket.batch.infrastructure.dto.response.OutboxMessage;
+import java.util.Map;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.JdbcPagingItemReader;
+import org.springframework.batch.item.database.Order;
+import org.springframework.batch.item.database.PagingQueryProvider;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+import org.springframework.batch.item.database.builder.JdbcPagingItemReaderBuilder;
+import org.springframework.batch.item.database.support.SqlPagingQueryProviderFactoryBean;
+import org.springframework.batch.item.support.CompositeItemWriter;
+import org.springframework.batch.item.support.builder.CompositeItemWriterBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.DataClassRowMapper;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class PaymentStepConfig {
+
+    private final ItemProcessor<OutboxMessage, Outbox> sinkOutboxProcessor;
+
+    @Bean
+    @Qualifier("paymentOutboxReader")
+    public JdbcPagingItemReader<OutboxMessage> paymentOutboxReader(DataSource dataSource)
+        throws Exception {
+        return new JdbcPagingItemReaderBuilder<OutboxMessage>()
+            .name("paymentOutboxReader")
+            .dataSource(dataSource)
+            .fetchSize(CHUNK_SIZE)
+            .pageSize(CHUNK_SIZE)
+            // 기본 생성자 대신 모든 필드를 지닌 생성자 매핑
+            .rowMapper(new DataClassRowMapper<>(OutboxMessage.class))
+            .queryProvider(paymentQueryProvider(dataSource))
+            .build();
+    }
+
+    @Bean
+    public PagingQueryProvider paymentQueryProvider(DataSource dataSource) throws Exception {
+        SqlPagingQueryProviderFactoryBean queryProvider = new SqlPagingQueryProviderFactoryBean();
+        queryProvider.setDataSource(dataSource);
+        queryProvider.setSelectClause("""
+            SELECT o.id, o.aggregate_type, o.aggregate_id, o.event_type, o.payload, o.retry_count,
+            o.success, o.created_at, o.sent_at
+            """);
+        queryProvider.setFromClause("FROM p_outbox o");
+        queryProvider.setWhereClause(
+            "WHERE o.success = true or (o.success = false and o.retry_count >= 3)");
+        queryProvider.setSortKeys(Map.of(
+            "id", Order.ASCENDING
+        ));
+        return queryProvider.getObject();
+    }
+
+    /* TODO : TransactionManager 변경
+        현재는 sink의 트랜잭션매니저만 가지고 있어 source에서는 롤백 발생 X
+    */
+    @Bean
+    public CompositeItemWriter<Outbox> paymentOutboxMigrateWriter(
+        DataSource sinkDataSource,
+        DataSource paymentDataSource
+    ) {
+
+        OutboxItemSqlParameterSourceProvider outboxParameterSource = new OutboxItemSqlParameterSourceProvider();
+        // payment -> sink로 복사
+        JdbcBatchItemWriter<Outbox> writeToSink = new JdbcBatchItemWriterBuilder<Outbox>()
+            .dataSource(sinkDataSource)
+            .sql("""
+                INSERT INTO p_outbox(id, aggregate_type, aggregate_id, event_type, payload, retry_count, success, created_at, sent_at, org_id)
+                VALUES (nextval('p_outbox_seq'), :aggregateType, :aggregateId, :eventType, :payload, :retryCount, :success, :createdAt, :sentAt, :orgId)
+                """)
+            .itemSqlParameterSourceProvider(outboxParameterSource)
+            .build();
+        writeToSink.afterPropertiesSet();
+
+        // payment에서 삭제
+        JdbcBatchItemWriter<Outbox> deletePayment = new JdbcBatchItemWriterBuilder<Outbox>()
+            .dataSource(paymentDataSource)
+            .sql("""
+                DELETE FROM p_outbox where id = :orgId
+                """)
+            .itemSqlParameterSourceProvider(outboxParameterSource)
+            .build();
+        deletePayment.afterPropertiesSet();
+
+        return new CompositeItemWriterBuilder<Outbox>()
+            .delegates(writeToSink, deletePayment)
+            .build();
+    }
+
+    @Bean
+    public Step collectPaymentOutboxStep(
+        JobRepository jobRepository,
+        @Qualifier("sinkTransactionManager") PlatformTransactionManager transactionManager,
+        @Qualifier("paymentDataSource") DataSource paymentDataSource,
+        @Qualifier("sinkDataSource") DataSource sinkDataSource
+    ) throws Exception {
+        return new StepBuilder("paymentOutboxCollectStep", jobRepository)
+            .<OutboxMessage, Outbox>chunk(CHUNK_SIZE, transactionManager)
+            .reader(paymentOutboxReader(paymentDataSource))
+            .processor(sinkOutboxProcessor)
+            .writer(paymentOutboxMigrateWriter(sinkDataSource, paymentDataSource))
+            .build();
+    }
+}

--- a/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/ReservationStepConfig.java
+++ b/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/ReservationStepConfig.java
@@ -1,0 +1,117 @@
+package com.earlybird.ticket.batch.infrastructure.config.jdbc;
+
+import static com.earlybird.ticket.batch.infrastructure.config.jdbc.OutboxCollectBatchConfig.CHUNK_SIZE;
+
+import com.earlybird.ticket.batch.domain.entity.Outbox;
+import com.earlybird.ticket.batch.infrastructure.dto.response.OutboxMessage;
+import java.util.Map;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.JdbcPagingItemReader;
+import org.springframework.batch.item.database.Order;
+import org.springframework.batch.item.database.PagingQueryProvider;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+import org.springframework.batch.item.database.builder.JdbcPagingItemReaderBuilder;
+import org.springframework.batch.item.database.support.SqlPagingQueryProviderFactoryBean;
+import org.springframework.batch.item.support.CompositeItemWriter;
+import org.springframework.batch.item.support.builder.CompositeItemWriterBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.DataClassRowMapper;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class ReservationStepConfig {
+
+    private final ItemProcessor<OutboxMessage, Outbox> sinkOutboxProcessor;
+
+    @Bean
+    @Qualifier("reservationOutboxReader")
+    public JdbcPagingItemReader<OutboxMessage> reservationOutboxReader(DataSource dataSource)
+        throws Exception {
+        return new JdbcPagingItemReaderBuilder<OutboxMessage>()
+            .name("reservationOutboxReader")
+            .dataSource(dataSource)
+            .fetchSize(CHUNK_SIZE)
+            .pageSize(CHUNK_SIZE)
+            // 기본 생성자 대신 모든 필드를 지닌 생성자 매핑
+            .rowMapper(new DataClassRowMapper<>(OutboxMessage.class))
+            .queryProvider(reservationQueryProvider(dataSource))
+            .build();
+    }
+
+    @Bean
+    public PagingQueryProvider reservationQueryProvider(DataSource dataSource) throws Exception {
+        SqlPagingQueryProviderFactoryBean queryProvider = new SqlPagingQueryProviderFactoryBean();
+        queryProvider.setDataSource(dataSource);
+        queryProvider.setSelectClause("""
+            SELECT o.id, o.aggregate_type, o.aggregate_id, o.event_type, o.payload, o.retry_count,
+            o.success, o.created_at, o.sent_at
+            """);
+        queryProvider.setFromClause("FROM p_outbox o");
+        queryProvider.setWhereClause(
+            "WHERE o.success = true or (o.success = false and o.retry_count >= 3)");
+        queryProvider.setSortKeys(Map.of(
+            "id", Order.ASCENDING
+        ));
+        return queryProvider.getObject();
+    }
+
+    @Bean
+    public CompositeItemWriter<Outbox> reservationOutboxMigrateWriter(
+        DataSource sinkDataSource,
+        DataSource reservationDataSource
+    ) {
+
+        OutboxItemSqlParameterSourceProvider outboxParameterSource = new OutboxItemSqlParameterSourceProvider();
+        // payment -> sink로 복사
+        JdbcBatchItemWriter<Outbox> writeToSink = new JdbcBatchItemWriterBuilder<Outbox>()
+            .dataSource(sinkDataSource)
+            .sql("""
+                INSERT INTO p_outbox(id, aggregate_type, aggregate_id, event_type, payload, retry_count, success, created_at, sent_at, org_id)
+                VALUES (nextval('p_outbox_seq'), :aggregateType, :aggregateId, :eventType, :payload, :retryCount, :success, :createdAt, :sentAt, :orgId)
+                """)
+            .itemSqlParameterSourceProvider(outboxParameterSource)
+            .build();
+        writeToSink.afterPropertiesSet();
+
+        // payment에서 삭제
+        JdbcBatchItemWriter<Outbox> deleteReservationOutbox = new JdbcBatchItemWriterBuilder<Outbox>()
+            .dataSource(reservationDataSource)
+            .sql("""
+                DELETE FROM p_outbox where id = :orgId
+                """)
+            .itemSqlParameterSourceProvider(outboxParameterSource)
+            .build();
+        deleteReservationOutbox.afterPropertiesSet();
+
+        return new CompositeItemWriterBuilder<Outbox>()
+            .delegates(writeToSink, deleteReservationOutbox)
+            .build();
+    }
+
+    /* TODO : TransactionManager 변경
+        현재는 sink의 트랜잭션매니저만 가지고 있어 source에서는 롤백 발생 X
+     */
+    @Bean
+    public Step collectReservationOutboxStep(
+        JobRepository jobRepository,
+        @Qualifier("sinkTransactionManager") PlatformTransactionManager transactionManager,
+        @Qualifier("reservationDataSource") DataSource reservationDataSource,
+        @Qualifier("sinkDataSource") DataSource sinkDataSource
+    ) throws Exception {
+        return new StepBuilder("reservationOutboxCollectStep", jobRepository)
+            .<OutboxMessage, Outbox>chunk(CHUNK_SIZE, transactionManager)
+            .reader(reservationOutboxReader(reservationDataSource))
+            .processor(sinkOutboxProcessor)
+            .writer(reservationOutboxMigrateWriter(sinkDataSource, reservationDataSource))
+            .build();
+    }
+}

--- a/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/VenueStepConfig.java
+++ b/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/VenueStepConfig.java
@@ -65,7 +65,7 @@ public class VenueStepConfig {
     }
 
     @Bean
-    public CompositeItemWriter<Outbox> concertOutboxMigrateWriter(
+    public CompositeItemWriter<Outbox> venueOutboxMigrateWriter(
         DataSource sinkDataSource,
         DataSource venueDataSource
     ) {
@@ -111,7 +111,7 @@ public class VenueStepConfig {
             .<OutboxMessage, Outbox>chunk(CHUNK_SIZE, transactionManager)
             .reader(venueOutboxReader(venueDataSource))
             .processor(sinkOutboxProcessor)
-            .writer(concertOutboxMigrateWriter(sinkDataSource, venueDataSource))
+            .writer(venueOutboxMigrateWriter(sinkDataSource, venueDataSource))
             .build();
     }
 }

--- a/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/VenueStepConfig.java
+++ b/batch/src/main/java/com/earlybird/ticket/batch/infrastructure/config/jdbc/VenueStepConfig.java
@@ -1,0 +1,117 @@
+package com.earlybird.ticket.batch.infrastructure.config.jdbc;
+
+import static com.earlybird.ticket.batch.infrastructure.config.jdbc.OutboxCollectBatchConfig.CHUNK_SIZE;
+
+import com.earlybird.ticket.batch.domain.entity.Outbox;
+import com.earlybird.ticket.batch.infrastructure.dto.response.OutboxMessage;
+import java.util.Map;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
+import org.springframework.batch.item.database.JdbcPagingItemReader;
+import org.springframework.batch.item.database.Order;
+import org.springframework.batch.item.database.PagingQueryProvider;
+import org.springframework.batch.item.database.builder.JdbcBatchItemWriterBuilder;
+import org.springframework.batch.item.database.builder.JdbcPagingItemReaderBuilder;
+import org.springframework.batch.item.database.support.SqlPagingQueryProviderFactoryBean;
+import org.springframework.batch.item.support.CompositeItemWriter;
+import org.springframework.batch.item.support.builder.CompositeItemWriterBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.DataClassRowMapper;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class VenueStepConfig {
+
+    private final ItemProcessor<OutboxMessage, Outbox> sinkOutboxProcessor;
+
+    @Bean
+    @Qualifier("venueOutboxReader")
+    public JdbcPagingItemReader<OutboxMessage> venueOutboxReader(DataSource dataSource)
+        throws Exception {
+        return new JdbcPagingItemReaderBuilder<OutboxMessage>()
+            .name("venueOutboxReader")
+            .dataSource(dataSource)
+            .fetchSize(CHUNK_SIZE)
+            .pageSize(CHUNK_SIZE)
+            // 기본 생성자 대신 모든 필드를 지닌 생성자 매핑
+            .rowMapper(new DataClassRowMapper<>(OutboxMessage.class))
+            .queryProvider(venueQueryProvider(dataSource))
+            .build();
+    }
+
+    @Bean
+    public PagingQueryProvider venueQueryProvider(DataSource dataSource) throws Exception {
+        SqlPagingQueryProviderFactoryBean queryProvider = new SqlPagingQueryProviderFactoryBean();
+        queryProvider.setDataSource(dataSource);
+        queryProvider.setSelectClause("""
+            SELECT o.id, o.aggregate_type, o.aggregate_id, o.event_type, o.payload, o.retry_count,
+            o.success, o.created_at, o.sent_at
+            """);
+        queryProvider.setFromClause("FROM p_outbox o");
+        queryProvider.setWhereClause(
+            "WHERE o.success = true or (o.success = false and o.retry_count >= 3)");
+        queryProvider.setSortKeys(Map.of(
+            "id", Order.ASCENDING
+        ));
+        return queryProvider.getObject();
+    }
+
+    @Bean
+    public CompositeItemWriter<Outbox> concertOutboxMigrateWriter(
+        DataSource sinkDataSource,
+        DataSource venueDataSource
+    ) {
+
+        OutboxItemSqlParameterSourceProvider outboxParameterSource = new OutboxItemSqlParameterSourceProvider();
+        // payment -> sink로 복사
+        JdbcBatchItemWriter<Outbox> writeToSink = new JdbcBatchItemWriterBuilder<Outbox>()
+            .dataSource(sinkDataSource)
+            .sql("""
+                INSERT INTO p_outbox(id, aggregate_type, aggregate_id, event_type, payload, retry_count, success, created_at, sent_at, org_id)
+                VALUES (nextval('p_outbox_seq'), :aggregateType, :aggregateId, :eventType, :payload, :retryCount, :success, :createdAt, :sentAt, :orgId)
+                """)
+            .itemSqlParameterSourceProvider(outboxParameterSource)
+            .build();
+        writeToSink.afterPropertiesSet();
+
+        // payment에서 삭제
+        JdbcBatchItemWriter<Outbox> deleteVenueOutbox = new JdbcBatchItemWriterBuilder<Outbox>()
+            .dataSource(venueDataSource)
+            .sql("""
+                DELETE FROM p_outbox where id = :orgId
+                """)
+            .itemSqlParameterSourceProvider(outboxParameterSource)
+            .build();
+        deleteVenueOutbox.afterPropertiesSet();
+
+        return new CompositeItemWriterBuilder<Outbox>()
+            .delegates(writeToSink, deleteVenueOutbox)
+            .build();
+    }
+
+    /* TODO : TransactionManager 변경
+        현재는 sink의 트랜잭션매니저만 가지고 있어 source에서는 롤백 발생 X
+     */
+    @Bean
+    public Step collectVenueOutboxStep(
+        JobRepository jobRepository,
+        @Qualifier("sinkTransactionManager") PlatformTransactionManager transactionManager,
+        @Qualifier("venueDataSource") DataSource venueDataSource,
+        @Qualifier("sinkDataSource") DataSource sinkDataSource
+    ) throws Exception {
+        return new StepBuilder("venueOutboxCollectStep", jobRepository)
+            .<OutboxMessage, Outbox>chunk(CHUNK_SIZE, transactionManager)
+            .reader(venueOutboxReader(venueDataSource))
+            .processor(sinkOutboxProcessor)
+            .writer(concertOutboxMigrateWriter(sinkDataSource, venueDataSource))
+            .build();
+    }
+}


### PR DESCRIPTION
## 변경 타입

- [x] 신규 기능 추가/수정
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 테스트 항목

- [ ] 코드가 의도한 대로 동작하는지 테스트 완료
- [ ] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음

## 변경 내용

- **as-is**
    - (변경 전 설명을 여기에 작성)

- **to-be**
    - 각 서비스별 읽기 -> 변환 -> 삽입 + 삭제 기능 추가

## 참조
- resolve #314 
- [ET-190](https://challduck.atlassian.net/jira/software/projects/ET/boards/36?selectedIssue=ET-190)

## 코멘트

- 계속 고민만 하면 진도가 아예 안나갈 것 같아서 일단 올리고, 개선해보겠습니다.

**개선 가능해보이는 포인트**
  - `AbstractRoutingDataSource`를 통한 DB 라우팅 추가
  - `JtaTransactionManager` 매니저를 통한 분산 트랜잭션 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - 결제, 쿠폰, 콘서트, 공연장, 관리자, 예약 데이터베이스의 아웃박스 메시지를 통합 저장소로 마이그레이션하는 배치 단계가 추가되었습니다.
    - 각 데이터 소스별로 아웃박스 메시지를 읽고, 처리 후 통합 저장소에 기록 및 원본 데이터 삭제가 자동으로 진행됩니다.
    - 여러 마이그레이션 단계를 순차적으로 실행하는 통합 배치 작업 구성이 도입되었습니다.

- **Refactor**
    - 배치 작업 구성이 단일 단계에서 다중 단계로 재구성되어 유지보수성과 확장성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->