### PR TITLE
[ET-203] refactoring(reservation) : 예약 조회 및 로그 설정

### DIFF
--- a/reservation/src/main/java/com/earlybird/ticket/reservation/application/handler/ConfirmSeatSuccessPayloadHandler.java
+++ b/reservation/src/main/java/com/earlybird/ticket/reservation/application/handler/ConfirmSeatSuccessPayloadHandler.java
@@ -35,15 +35,7 @@ public class ConfirmSeatSuccessPayloadHandler implements EventHandler<SeatConfir
                                                  .getReservation();
 
         reservation.updateStatusConfirm(userId);
-        log.info("조회된 seatInstanceList 개수: {}",
-                 seatIntanceList.size());
-        seatIntanceList.forEach(seat -> {
-            log.info("수정 전 상태: {}",
-                     seat.getStatus());
-            seat.updateStatusConfirm(userId);
-            log.info("수정 후 상태: {}",
-                     seat.getStatus());
-        });
+        seatIntanceList.forEach(seat -> seat.updateStatusConfirm(userId));
 
 
     }

--- a/reservation/src/main/java/com/earlybird/ticket/reservation/application/handler/ReserveCouponPayloadHandler.java
+++ b/reservation/src/main/java/com/earlybird/ticket/reservation/application/handler/ReserveCouponPayloadHandler.java
@@ -34,8 +34,6 @@ public class ReserveCouponPayloadHandler implements EventHandler<CouponReservePa
     @Override
     @Transactional
     public void handle(Event<CouponReservePayload> event) {
-        log.info("[CouponEventHandler] 이벤트 수신: {}",
-                 event);
 
         CouponReservePayload payload = event.getPayload();
         if (payload == null) {
@@ -75,11 +73,7 @@ public class ReserveCouponPayloadHandler implements EventHandler<CouponReservePa
         String payloadJson;
         try {
             payloadJson = new ObjectMapper().writeValueAsString(couponConfirmPayloadEvent);
-            log.info("[CouponEventHandler] 직렬화된 ConfirmCouponPayload: {}",
-                     payloadJson);
         } catch (JsonProcessingException e) {
-            log.error("[CouponEventHandler] ConfirmCouponPayload 직렬화 실패",
-                      e);
             throw new CustomJsonProcessingException();
         }
 

--- a/reservation/src/main/java/com/earlybird/ticket/reservation/application/handler/ReturnSeatSuccessPayloadHandler.java
+++ b/reservation/src/main/java/com/earlybird/ticket/reservation/application/handler/ReturnSeatSuccessPayloadHandler.java
@@ -30,15 +30,7 @@ public class ReturnSeatSuccessPayloadHandler implements EventHandler<SeatReturnS
 
         List<ReservationSeat> seatIntanceList = reservationSeatRepository.findAllBySeatInstaceIdIn(payload.seatInstanceIdList());
 
-        log.info("조회된 seatInstanceList 개수: {}",
-                 seatIntanceList.size());
-        seatIntanceList.forEach(seat -> {
-            log.info("수정 전 상태: {}",
-                     seat.getStatus());
-            seat.updateStatusFREE(userId);
-            log.info("수정 후 상태: {}",
-                     seat.getStatus());
-        });
+        seatIntanceList.forEach(seat -> seat.updateStatusFREE(userId));
 
         seatIntanceList.forEach(reservationSeat -> {
             reservationSeat.updateStatusFREE(userId);
@@ -46,9 +38,6 @@ public class ReturnSeatSuccessPayloadHandler implements EventHandler<SeatReturnS
             reservation.updateStatusCancelled(userId);
         });
 
-        seatIntanceList.forEach(seat -> log.info("업데이트 후 상태 확인: id={}, status={}",
-                                                 seat.getSeatInstanceId(),
-                                                 seat.getStatus()));
 
     }
 

--- a/reservation/src/main/java/com/earlybird/ticket/reservation/application/handler/TestPayloadHandler.java
+++ b/reservation/src/main/java/com/earlybird/ticket/reservation/application/handler/TestPayloadHandler.java
@@ -13,6 +13,7 @@ public class TestPayloadHandler implements EventHandler<TestPayload> {
 
     @Override
     public void handle(Event<TestPayload> event) {
+
         log.info("[TestPayloadHandler] 처리 시작 - Payload: {}",
                  event.getPayload()
                       .getTest());

--- a/reservation/src/main/java/com/earlybird/ticket/reservation/application/service/ReservationServiceImpl.java
+++ b/reservation/src/main/java/com/earlybird/ticket/reservation/application/service/ReservationServiceImpl.java
@@ -250,7 +250,7 @@ public class ReservationServiceImpl implements ReservationService {
     public FindReservationQuery findReservation(UUID reservationId,
                                                 String passport) {
 
-        Reservation reservation = reservationRepository.findById(reservationId)
+        Reservation reservation = reservationRepository.findByIdAndReservationStatusConfirmed(reservationId)
                                                        .orElseThrow(NotFoundReservationException::new);
 
         List<ReservationSeat> reservationSeatList = reservationSeatRepository.findByReservation(reservation);

--- a/reservation/src/main/java/com/earlybird/ticket/reservation/domain/repository/ReservationRepository.java
+++ b/reservation/src/main/java/com/earlybird/ticket/reservation/domain/repository/ReservationRepository.java
@@ -12,4 +12,6 @@ public interface ReservationRepository {
     Optional<Reservation> findById(UUID reservationId);
 
     List<Reservation> findAllById(List<UUID> reservationIds);
+
+    Optional<Reservation> findByIdAndReservationStatusConfirmed(UUID reservationId);
 }

--- a/reservation/src/main/java/com/earlybird/ticket/reservation/infrastructure/messaging/producer/KafkaProducerInterceptor.java
+++ b/reservation/src/main/java/com/earlybird/ticket/reservation/infrastructure/messaging/producer/KafkaProducerInterceptor.java
@@ -31,6 +31,15 @@ public class KafkaProducerInterceptor implements ProducerInterceptor<String, Str
         logData.put("timestamp",
                     System.currentTimeMillis());
 
+        if (producerRecord.headers() != null) {
+            var header = producerRecord.headers()
+                                       .lastHeader("traceId");
+            if (header != null) {
+                logData.put("traceId",
+                            header.value());
+            }
+        }
+
         try {
             log.info("Kafka Interceptor Log: {}",
                      objectMapper.writeValueAsString(logData));
@@ -47,6 +56,7 @@ public class KafkaProducerInterceptor implements ProducerInterceptor<String, Str
                                   Exception exception) {
         log.info("onAcknowledgement start");
 
+
         Map<String, Object> logData = new HashMap<>();
         logData.put("event",
                     "kafka_ack");
@@ -58,6 +68,7 @@ public class KafkaProducerInterceptor implements ProducerInterceptor<String, Str
                     metadata.offset());
         logData.put("timestamp",
                     System.currentTimeMillis());
+
 
         if (exception != null) {
             logData.put("status",

--- a/reservation/src/main/java/com/earlybird/ticket/reservation/infrastructure/messaging/producer/KafkaProducerListener.java
+++ b/reservation/src/main/java/com/earlybird/ticket/reservation/infrastructure/messaging/producer/KafkaProducerListener.java
@@ -7,6 +7,7 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.springframework.kafka.support.ProducerListener;
 import org.springframework.stereotype.Component;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,6 +34,16 @@ public class KafkaProducerListener implements ProducerListener<String, String> {
                     producerRecord.value());
         logData.put("timestamp",
                     System.currentTimeMillis());
+        if (producerRecord.headers() != null) {
+            var header = producerRecord.headers()
+                                       .lastHeader("traceId");
+            if (header != null) {
+                logData.put("traceId",
+                            new String(header.value(),
+                                       StandardCharsets.UTF_8));
+
+            }
+        }
 
         try {
             log.info("Kafka Success Log: {}",

--- a/reservation/src/main/java/com/earlybird/ticket/reservation/infrastructure/messaging/producer/ReservationKafkaOutboxProducer.java
+++ b/reservation/src/main/java/com/earlybird/ticket/reservation/infrastructure/messaging/producer/ReservationKafkaOutboxProducer.java
@@ -4,11 +4,14 @@ import com.earlybird.ticket.reservation.domain.entity.Outbox;
 import com.earlybird.ticket.reservation.domain.repository.OutboxRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.slf4j.MDC;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -19,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 public class ReservationKafkaOutboxProducer {
 
     private static final String DLT_SUFFIX = ".DLT";
+    private static final String TRACE_ID = "traceId";
 
     private final OutboxRepository outboxRepository;
     private final KafkaTemplate<String, String> kafkaTemplate;
@@ -27,6 +31,7 @@ public class ReservationKafkaOutboxProducer {
     @Transactional
     public void publishPendingOutboxMessages() {
         List<Outbox> pendingOutboxes = outboxRepository.findTOP100ByOrderByCreatedAtAsc();
+        String traceId = MDC.get(TRACE_ID);
 
         List<CompletableFuture<Outbox>> futures = pendingOutboxes.stream()
                                                                  .map(outbox -> {
@@ -41,12 +46,19 @@ public class ReservationKafkaOutboxProducer {
                                                                               topic,
                                                                               payload);
 
-                                                                     return kafkaTemplate.send(topic,
-                                                                                               key,
-                                                                                               payload)
+                                                                     ProducerRecord<String, String> record = new ProducerRecord<>(topic,
+                                                                                                                                  key,
+                                                                                                                                  payload);
+                                                                     if (traceId != null) {
+                                                                         record.headers()
+                                                                               .add(TRACE_ID,
+                                                                                    traceId.getBytes(StandardCharsets.UTF_8));
+                                                                     }
+                                                                     return kafkaTemplate.send(record)
                                                                                          .handle((res, ex) -> {
                                                                                              if (ex != null) {
-                                                                                                 log.error("[발행 실패] id = {}, retryCount = {}",
+                                                                                                 log.error("[Kafka 발행 실패] traceId = {}, id = {}, retryCount = {}",
+                                                                                                           traceId,
                                                                                                            outbox.getId(),
                                                                                                            outbox.getRetryCount(),
                                                                                                            ex);
@@ -55,12 +67,30 @@ public class ReservationKafkaOutboxProducer {
                                                                                                  if (outbox.getRetryCount() > 3) {
                                                                                                      log.warn("[DLQ 이동] 3회 이상 실패한 이벤트 → {}",
                                                                                                               outbox.getId());
-                                                                                                     kafkaTemplate.send(topic + DLT_SUFFIX,
-                                                                                                                        key,
-                                                                                                                        payload);
+                                                                                                     ProducerRecord<String, String> dltRecord = new ProducerRecord<>(topic + DLT_SUFFIX,
+                                                                                                                                                                     key,
+                                                                                                                                                                     payload);
+                                                                                                     dltRecord.headers()
+                                                                                                              .add(TRACE_ID,
+                                                                                                                   Objects.requireNonNull(traceId)
+                                                                                                                          .getBytes(StandardCharsets.UTF_8));
+                                                                                                     kafkaTemplate.send(dltRecord);
                                                                                                  }
                                                                                              } else {
-                                                                                                 outbox.markSuccess();
+                                                                                                 try {
+                                                                                                     MDC.put(TRACE_ID,
+                                                                                                             traceId);
+                                                                                                     log.info("[Kafka 발행 성공] traceId = {}, offset = {}",
+                                                                                                              traceId,
+                                                                                                              res.getRecordMetadata()
+                                                                                                                 .offset());
+                                                                                                     outbox.markSuccess();
+                                                                                                 } catch (Exception e) {
+                                                                                                     log.error(e.getMessage(),
+                                                                                                               e);
+                                                                                                 } finally {
+                                                                                                     MDC.clear();
+                                                                                                 }
                                                                                              }
                                                                                              return outbox;
                                                                                          });
@@ -75,7 +105,8 @@ public class ReservationKafkaOutboxProducer {
                              outboxRepository.saveAll(updatedOutboxes);
                          })
                          .exceptionally(ex -> {
-                             log.error("[Outbox 저장 중 예외 발생]",
+                             log.error("[Outbox 저장 중 예외] traceId = {}",
+                                       traceId,
                                        ex);
                              return null;
                          });

--- a/reservation/src/main/java/com/earlybird/ticket/reservation/infrastructure/repository/reservation/ReservationJpaRepository.java
+++ b/reservation/src/main/java/com/earlybird/ticket/reservation/infrastructure/repository/reservation/ReservationJpaRepository.java
@@ -3,7 +3,11 @@ package com.earlybird.ticket.reservation.infrastructure.repository.reservation;
 import com.earlybird.ticket.reservation.domain.entity.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface ReservationJpaRepository extends JpaRepository<Reservation, UUID> {
+    Optional<Reservation> findById(UUID reservationId);
+
+    Optional<Reservation> findByIdAndReservationStatusConfirmed(UUID reservationId);
 }

--- a/reservation/src/main/java/com/earlybird/ticket/reservation/infrastructure/repository/reservation/ReservationRepositoryImpl.java
+++ b/reservation/src/main/java/com/earlybird/ticket/reservation/infrastructure/repository/reservation/ReservationRepositoryImpl.java
@@ -29,4 +29,9 @@ public class ReservationRepositoryImpl implements ReservationRepository {
     public List<Reservation> findAllById(List<UUID> reservationIds) {
         return reservationRepository.findAllById(reservationIds);
     }
+
+    @Override
+    public Optional<Reservation> findByIdAndReservationStatusConfirmed(UUID reservationId) {
+        return reservationRepository.findByIdAndReservationStatusConfirmed(reservationId);
+    }
 }

--- a/reservation/src/main/java/com/earlybird/ticket/reservation/presentation/ReservationExternalController.java
+++ b/reservation/src/main/java/com/earlybird/ticket/reservation/presentation/ReservationExternalController.java
@@ -6,7 +6,10 @@ import com.earlybird.ticket.reservation.application.dto.response.FindReservation
 import com.earlybird.ticket.reservation.application.service.ReservationService;
 import com.earlybird.ticket.reservation.domain.dto.response.ReservationSearchResult;
 import com.earlybird.ticket.reservation.presentation.dto.response.FindReservationResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedModel;
@@ -14,11 +17,15 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/external/reservations")
+@Slf4j
 public class ReservationExternalController {
 
     private final ReservationService reservationService;
@@ -91,10 +98,20 @@ public class ReservationExternalController {
     public ResponseEntity<CommonDto<Void>> test() {
         reservationService.test();
 
+        log.info("check MDC ={}",
+                 MDC.get("traceId"));
         return ResponseEntity.status(HttpStatus.OK)
                              .body(CommonDto.ok(null,
                                                 "test"));
     }
 
-
+    @GetMapping("/debug/headers")
+    public ResponseEntity<Map<String, String>> debugHeaders(HttpServletRequest request) {
+        Map<String, String> headers = Collections.list(request.getHeaderNames())
+                                                 .stream()
+                                                 .collect(Collectors.toMap(h -> h,
+                                                                           request::getHeader));
+        return ResponseEntity.ok(headers);
+    }
 }
+

--- a/reservation/src/main/resources/application.yml
+++ b/reservation/src/main/resources/application.yml
@@ -31,6 +31,9 @@ spring:
 
 server:
   port: 18088
+  tomcat:
+    mbeanregistry:
+      enabled: true
 
 
 management:
@@ -45,12 +48,18 @@ management:
     distribution:
       percentiles-histogram:
         all: true
+    enable:
+      jvm: true
   zipkin:
     tracing:
       endpoint: "http://${ZIPKIN_HOST:localhost}:${ZIPKIN_PORT:9411}/api/v2/spans"
   tracing:
     sampling:
       probability: ${ZIPKIN_SAMPLING_PROBABILITY:1.0}
+  prometheus:
+    metrics:
+      export:
+        enabled: true
 
 
 eureka:


### PR DESCRIPTION
## 변경 타입

- [] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 테스트 항목

- [x] 코드가 의도한 대로 동작하는지 테스트 완료
- [x] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음

## 변경 내용

- **as-is**
    - (변경 전 설명을 여기에 작성)

- **to-be**
    - kafka 로그 추가 및 불필요한 로그 제거

## 참조

[ET-203](https://challduck.atlassian.net/jira/software/projects/ET/boards/36?selectedIssue=ET-203)

## 코멘트

- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 모든 HTTP 요청 헤더를 JSON으로 반환하는 디버그 엔드포인트(`/debug/headers`)가 추가되었습니다.
- **버그 수정**
    - 예약 조회 시, 상태가 '확정'된 예약만 조회하도록 동작이 변경되었습니다.
- **개선 및 변경**
    - Kafka 메시지에 traceId 헤더가 추가되어 추적성이 향상되었습니다.
    - 로그 및 추적 관련 기능이 강화되었습니다.
    - 불필요한 중간 로그가 제거되어 처리 과정이 간소화되었습니다.
- **운영 및 모니터링**
    - Prometheus 및 JVM 메트릭, Tomcat MBean 등 모니터링 기능이 활성화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->