### PR TITLE
Feat(payment)/process reservation cancel event

### DIFF
--- a/payment/src/main/java/com/earlybird/ticket/payment/application/TemporaryStore.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/application/TemporaryStore.java
@@ -12,4 +12,6 @@ public interface TemporaryStore {
     void cacheConfirmedPayment(UUID reservationId);
 
     LocalDateTime getExpireDate(UUID reservationId);
+
+    Long getRemainingTime(UUID reservationId);
 }

--- a/payment/src/main/java/com/earlybird/ticket/payment/application/event/dto/request/PaymentCancelFailedEvent.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/application/event/dto/request/PaymentCancelFailedEvent.java
@@ -1,0 +1,15 @@
+package com.earlybird.ticket.payment.application.event.dto.request;
+
+
+import com.earlybird.ticket.common.entity.EventPayload;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record PaymentCancelFailedEvent(
+    UUID paymentId,
+    UUID reservationId,
+    String paymentKey
+) implements EventPayload {
+
+}

--- a/payment/src/main/java/com/earlybird/ticket/payment/application/event/dto/request/PaymentFailEvent.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/application/event/dto/request/PaymentFailEvent.java
@@ -1,10 +1,19 @@
 package com.earlybird.ticket.payment.application.event.dto.request;
 
 import com.earlybird.ticket.common.entity.EventPayload;
+import com.earlybird.ticket.common.entity.PassportDto;
+import com.earlybird.ticket.payment.domain.entity.constant.PaymentMethod;
+import com.earlybird.ticket.payment.domain.entity.constant.PaymentStatus;
 import java.util.UUID;
+import lombok.Builder;
 
+@Builder
 public record PaymentFailEvent(
-    UUID paymentId
+    UUID paymentId,
+    UUID reservationId,
+    PassportDto passportDto,
+    PaymentMethod paymentMethod,
+    PaymentStatus paymentStatus
 ) implements EventPayload {
 
 }

--- a/payment/src/main/java/com/earlybird/ticket/payment/application/service/dto/command/UpdatePaymentCommand.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/application/service/dto/command/UpdatePaymentCommand.java
@@ -4,6 +4,7 @@ import com.earlybird.ticket.payment.domain.entity.Payment;
 import com.earlybird.ticket.payment.domain.entity.constant.PaymentMethod;
 import com.earlybird.ticket.payment.domain.entity.constant.PaymentStatus;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.Builder;
 
 @Builder
@@ -11,6 +12,7 @@ public record UpdatePaymentCommand(
     PaymentMethod paymentMethod,
     PaymentStatus status,
     String paymentKey,
+    UUID reservationId,
     LocalDateTime approvedAt
 ) {
 
@@ -18,6 +20,7 @@ public record UpdatePaymentCommand(
         return Payment.builder()
             .userId(userId)
             .method(this.paymentMethod)
+            .reservationId(this.reservationId)
             .status(this.status)
             .paymentKey(this.paymentKey)
             .build();

--- a/payment/src/main/java/com/earlybird/ticket/payment/application/service/exception/PaymentCancelClientFailedException.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/application/service/exception/PaymentCancelClientFailedException.java
@@ -1,0 +1,10 @@
+package com.earlybird.ticket.payment.application.service.exception;
+
+import com.earlybird.ticket.common.entity.constant.Code;
+
+public class PaymentCancelClientFailedException extends PaymentCancelException {
+
+    public PaymentCancelClientFailedException() {
+        super("결제 중 [클라이언트]문제가 발생했습니다. 다시 시도해주세요.", Code.CONFLICT);
+    }
+}

--- a/payment/src/main/java/com/earlybird/ticket/payment/application/service/exception/PaymentCancelException.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/application/service/exception/PaymentCancelException.java
@@ -4,7 +4,11 @@ import com.earlybird.ticket.common.entity.constant.Code;
 
 public class PaymentCancelException extends AbstractPaymentException {
 
+    protected PaymentCancelException(String message, Code code) {
+        super(message, code);
+    }
+
     public PaymentCancelException() {
-        super("결제 취소 중 문제가 발생했습니다. 다시 시도해주세요.", Code.CONFLICT);
+        super("결제 중 문제가 발생했습니다. 다시 시도해주세요.", Code.CONFLICT);
     }
 }

--- a/payment/src/main/java/com/earlybird/ticket/payment/application/service/exception/PaymentCancelServerFailedException.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/application/service/exception/PaymentCancelServerFailedException.java
@@ -1,0 +1,10 @@
+package com.earlybird.ticket.payment.application.service.exception;
+
+import com.earlybird.ticket.common.entity.constant.Code;
+
+public class PaymentCancelServerFailedException extends PaymentCancelException {
+
+    public PaymentCancelServerFailedException() {
+        super("결제 취소 중 [서버]문제가 발생했습니다. 다시 시도해주세요.", Code.CONFLICT);
+    }
+}

--- a/payment/src/main/java/com/earlybird/ticket/payment/common/EventType.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/common/EventType.java
@@ -1,8 +1,9 @@
 package com.earlybird.ticket.payment.common;
 
 import com.earlybird.ticket.common.entity.EventPayload;
-import com.earlybird.ticket.payment.application.event.dto.request.PaymentSuccessEvent;
+import com.earlybird.ticket.payment.application.event.dto.request.PaymentCancelFailedEvent;
 import com.earlybird.ticket.payment.application.event.dto.request.PaymentFailEvent;
+import com.earlybird.ticket.payment.application.event.dto.request.PaymentSuccessEvent;
 import com.earlybird.ticket.payment.application.event.dto.response.ReservationCancelPayload;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -14,8 +15,9 @@ import lombok.extern.slf4j.Slf4j;
 public enum EventType {
     PAYMENT_SUCCESS(PaymentSuccessEvent.class, Topic.PAYMENT_TO_RESERVATION_TOPIC),
     PAYMENT_FAIL(PaymentFailEvent.class, Topic.PAYMENT_TO_RESERVATION_TOPIC),
-//    PAYMENT_CANCEL(PaymentSuccessEvent.class, Topic.PAYMENT_TO_PAYMENT_TOPIC),
-    RESERVATION_CANCEL(ReservationCancelPayload.class, Topic.RESERVATION_TO_PAYMENT_TOPIC)
+    PAYMENT_CANCEL_FAIL(PaymentCancelFailedEvent.class, Topic.PAYMENT_TO_PAYMENT_TOPIC_DLQ),
+    //    PAYMENT_CANCEL(PaymentExpiredEvent.class, Topic.PAYMENT_TO_PAYMENT_TOPIC),
+    RESERVATION_CANCEL(ReservationCancelPayload.class, Topic.RESERVATION_TO_PAYMENT_TOPIC),
     ;
 
     private final Class<? extends EventPayload> payloadClass;
@@ -34,7 +36,8 @@ public enum EventType {
 
         public static final String PAYMENT_TO_RESERVATION_TOPIC = "PaymentToReservation";
         public static final String RESERVATION_TO_PAYMENT_TOPIC = "ReservationToPayment";
-//        public static final String PAYMENT_TO_PAYMENT_TOPIC = "PaymentToPayment";
+        //        public static final String PAYMENT_TO_PAYMENT_TOPIC = "PaymentToPayment";
+        public static final String PAYMENT_TO_PAYMENT_TOPIC_DLQ = "PaymentToPayment.DLT";
 
     }
 }

--- a/payment/src/main/java/com/earlybird/ticket/payment/domain/entity/Payment.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/domain/entity/Payment.java
@@ -101,4 +101,12 @@ public class Payment extends BaseEntity {
         this.delete(this.userId);
     }
 
+    public void expirePayment(Payment expired) {
+        if (!this.getReservationId().equals(expired.reservationId)) {
+            throw new PaymentNotFoundException();
+        }
+        this.status = PaymentStatus.EXPIRED;
+        this.delete(this.userId);
+    }
+
 }

--- a/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/cache/PaymentRedisTemporaryStore.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/cache/PaymentRedisTemporaryStore.java
@@ -53,6 +53,7 @@ public class PaymentRedisTemporaryStore implements TemporaryStore {
         }
     }
 
+    @Deprecated
     @Override
     public LocalDateTime getExpireDate(UUID reservationId) {
         String key = RESERVATION_KEY + reservationId;
@@ -64,5 +65,13 @@ public class PaymentRedisTemporaryStore implements TemporaryStore {
             .atZone(ZoneId.systemDefault())
             .plusSeconds(bucket.getExpireTime())
             .toLocalDateTime();
+    }
+
+    @Override
+    public Long getRemainingTime(UUID reservationId) {
+        String key = RESERVATION_KEY + reservationId;
+
+        RBucket<Object> bucket = redissonClient.getBucket(key);
+        return bucket.getExpireTime();
     }
 }

--- a/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/client/dto/response/ProcessPaymentConfirmClientResponse.java
+++ b/payment/src/main/java/com/earlybird/ticket/payment/infrastructure/client/dto/response/ProcessPaymentConfirmClientResponse.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.util.UUID;
 import lombok.Builder;
 
 @Builder
@@ -15,7 +16,7 @@ public record ProcessPaymentConfirmClientResponse(
     String method,
     String status,
     String paymentKey,
-
+    @JsonProperty("orderId") UUID reservationId,
     @JsonProperty("approvedAt")
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
     OffsetDateTime approvedAt,
@@ -32,6 +33,7 @@ public record ProcessPaymentConfirmClientResponse(
             .paymentMethod(PaymentMethod.from(method))
             .status(PaymentStatus.from(status))
             .paymentKey(paymentKey)
+            .reservationId(reservationId)
             .approvedAt(transformDate())
             .build();
     }


### PR DESCRIPTION
## 변경 타입

- [] 신규 기능 추가/수정
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 테스트 항목

- [ ] 코드가 의도한 대로 동작하는지 테스트 완료
- [ ] 기존 기능에 영향을 주지 않음
- [ ] 관련 문서를 업데이트했거나 업데이트가 필요하지 않음

## 변경 내용

- **as-is**
    - (변경 전 설명을 여기에 작성)

- **to-be**
    - 결제 취소 API 재시도 로직 부여
    - 결제 취소 3회 실패 시 DLQ로 이동
    - 예약 TTL이 결제 예상 수행 시간 미만일 경우 결제 진행하지 않도록 수정

## 참조

[ET-1157](https://challduck.atlassian.net/jira/software/projects/ET/boards/36?selectedIssue=ET-157)

## 코멘트

- (추가적인 설명이나 코멘트가 필요한 경우 여기에 작성)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 결제 취소 실패 이벤트 및 관련 예외 처리 기능이 추가되었습니다.
    - 결제 만료 처리 기능이 도입되었습니다.
    - 결제 실패 이벤트에 예약 ID, 결제 방법 등 추가 정보가 포함됩니다.

- **버그 수정**
    - 결제 취소 시 클라이언트/서버 오류를 구분하여 처리하고, 3회 재시도 후 실패 시 별도 이벤트가 생성됩니다.

- **개선 사항**
    - 결제 임시 저장소에서 남은 시간 확인 기능이 추가되었습니다.
    - 여러 데이터 객체에 예약 ID 필드가 추가되었습니다.
    - 일부 메서드가 더 이상 사용되지 않음을 표시(Deprecated)하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->